### PR TITLE
chore:(gatsby-plugin-fastify): Update docs and rename client paths

### DIFF
--- a/.changeset/clean-seahorses-sniff.md
+++ b/.changeset/clean-seahorses-sniff.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": minor
+---
+
+Updated client path name to client routes so imports changed to import { handleClientOnlyRoutes } from "./clientRoutes";

--- a/.changeset/modern-mangos-juggle.md
+++ b/.changeset/modern-mangos-juggle.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": minor
+---
+
+Remove fastify plugins from peer deps to normal dependencies. Only Gatsby and fastify are peer deps now.

--- a/packages/gatsby-plugin-fastify/README.md
+++ b/packages/gatsby-plugin-fastify/README.md
@@ -20,14 +20,14 @@
 
 `gatsby-plugin-fastify` gives you a way to integrate your Gatsby site with a Node.js server using Fastify. Use to serve a standard Gatsby.js site normally - the plugin will take care of everything:
 
-- Serving Gatsby Functions
-- Serving static files
-- Serving DSG/SSR Routes
-- Gatsby 404 page
-- Gatsby 500 page
-- Gatsby redirects
-- Client-side paths
-- Serving the site with pathPrefix - set it up inside `gatsby-config.js`, the plugin will take care of it
+- Serving [Gatsby Functions](https://www.gatsbyjs.com/docs/reference/functions/)
+- Serving [static files](https://www.gatsbyjs.com/docs/caching/#static-files)
+- Serving [DSG](https://www.gatsbyjs.com/docs/reference/rendering-options/deferred-static-generation/)/[SSR](https://www.gatsbyjs.com/docs/reference/rendering-options/server-side-rendering/) Routes
+- Gatsby [404 page](https://www.gatsbyjs.com/docs/how-to/adding-common-features/add-404-page/)
+- Gatsby [500 page](https://www.gatsbyjs.com/docs/how-to/adding-common-features/add-500-page/)
+- Gatsby [redirects](https://www.gatsbyjs.com/docs/reference/config-files/actions/#createRedirect)
+- [Client-side routes](https://www.gatsbyjs.com/docs/how-to/routing/client-only-routes-and-user-authentication)
+- Serving the site with [pathPrefix](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/) - set it up inside `gatsby-config.js`, the plugin will take care of it
 - File compression, Etags, and more.
 
 # Installation

--- a/packages/gatsby-plugin-fastify/README.md
+++ b/packages/gatsby-plugin-fastify/README.md
@@ -26,7 +26,7 @@
 - Gatsby [404 page](https://www.gatsbyjs.com/docs/how-to/adding-common-features/add-404-page/)
 - Gatsby [500 page](https://www.gatsbyjs.com/docs/how-to/adding-common-features/add-500-page/)
 - Gatsby [redirects](https://www.gatsbyjs.com/docs/reference/config-files/actions/#createRedirect)
-- [Client-side routes](https://www.gatsbyjs.com/docs/how-to/routing/client-only-routes-and-user-authentication)
+- [Client-only routes](https://www.gatsbyjs.com/docs/how-to/routing/client-only-routes-and-user-authentication)
 - Serving the site with [pathPrefix](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/) - set it up inside `gatsby-config.js`, the plugin will take care of it
 - File compression, Etags, and more.
 
@@ -117,7 +117,7 @@ Finally, each of the Gatsby features (functions, static files, redirects, client
 ```js
 import { handle404 } from "gatsby-plugin-fastify/plugins/404";
 import { handle500 } from "gatsby-plugin-fastify/plugins/500";
-import { handleClientOnlyPaths } from "gatsby-plugin-fastify/plugins/clientPaths";
+import { handleClientOnlyRoutes } from "gatsby-plugin-fastify/plugins/clientRoutes";
 import { handleFunctions } from "gatsby-plugin-fastify/plugins/functions";
 import { handleRedirects } from "gatsby-plugin-fastify/plugins/redirects";
 import { handleStatic } from "gatsby-plugin-fastify/plugins/static";

--- a/packages/gatsby-plugin-fastify/README.md
+++ b/packages/gatsby-plugin-fastify/README.md
@@ -35,7 +35,7 @@
 Install the plugin using npm or yarn
 
 ```sh
-npm install gatsby-plugin-fastify fastify fastify-static fastify-compress fastify-plugin fastify-accepts
+npm install gatsby-plugin-fastify fastify
 ```
 
 and add it to your `gatsby-config.js`

--- a/packages/gatsby-plugin-fastify/package.json
+++ b/packages/gatsby-plugin-fastify/package.json
@@ -32,6 +32,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.16.0",
+    "fastify-accepts": "^2.1.0",
+    "fastify-compress": "^3.6.1",
+    "fastify-plugin": "^3.0.0",
+    "fastify-static": "^4.5.0",
     "fs-extra": "^10.0.0",
     "open": "^8.4.0",
     "picomatch": "^2.3.0",
@@ -48,20 +52,12 @@
     "babel-preset-gatsby-package": "^1.14.0",
     "cross-env": "^7.0.3",
     "fastify": "^3.23.0",
-    "fastify-accepts": "^2.1.0",
-    "fastify-compress": "^3.6.1",
-    "fastify-plugin": "^3.0.0",
-    "fastify-static": "^4.5.0",
     "gatsby": "^4.1.0",
     "gatsby-plugin-utils": "^2.1.0",
     "jest": "^27.3.1"
   },
   "peerDependencies": {
     "fastify": "^3.19.0",
-    "fastify-accepts": "^2.1.0",
-    "fastify-compress": "^3.6.0",
-    "fastify-plugin": "^3.0.0",
-    "fastify-static": "^4.2.0",
     "gatsby": "^4.0.0"
   },
   "engines": {

--- a/packages/gatsby-plugin-fastify/src/plugins/clientRoutes.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/clientRoutes.ts
@@ -10,7 +10,7 @@ export type PathConfig = {
   path: string;
 };
 
-export const handleClientOnlyPaths: FastifyPluginAsync<{
+export const handleClientOnlyRoutes: FastifyPluginAsync<{
   paths: NoUndefinedField<PathConfig>[];
 }> = async (fastify, { paths }) => {
   fastify.log.info(`Registering ${paths?.length} client-only route(s)`);

--- a/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
@@ -1,4 +1,4 @@
-import { handleClientOnlyPaths } from "./clientPaths";
+import { handleClientOnlyRoutes } from "./clientRoutes";
 import { handleFunctions } from "./functions";
 import { handleRedirects } from "./redirects";
 import { handleStatic } from "./static";
@@ -38,7 +38,7 @@ export const serveGatsby: FastifyPluginAsync = async (fastify) => {
   await fastify.register(handleStatic, {});
 
   // Gatsby Client Only Routes
-  await fastify.register(handleClientOnlyPaths, {
+  await fastify.register(handleClientOnlyRoutes, {
     paths: clientSideRoutes,
   });
 

--- a/test-sites/fastify/package.json
+++ b/test-sites/fastify/package.json
@@ -17,9 +17,6 @@
   },
   "dependencies": {
     "fastify": "^3.22.1",
-    "fastify-accepts": "^2.0.1",
-    "fastify-compress": "^3.6.1",
-    "fastify-static": "^4.4.2",
     "gatsby": "^4.0.0",
     "gatsby-plugin-fastify": "*",
     "gatsby-plugin-image": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8539,7 +8539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastify-accepts@npm:^2.0.1, fastify-accepts@npm:^2.1.0":
+"fastify-accepts@npm:^2.1.0":
   version: 2.1.0
   resolution: "fastify-accepts@npm:2.1.0"
   dependencies:
@@ -8582,21 +8582,6 @@ __metadata:
   version: 3.0.0
   resolution: "fastify-plugin@npm:3.0.0"
   checksum: 00324690789ee02f977ab58ba70d937e2e420a6813a6aa7ae3ba47e34022dc8ac40e15a36ab14a67d94474de984398b1c8b30279fb51d92966f5d3d3ebd1b6fa
-  languageName: node
-  linkType: hard
-
-"fastify-static@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "fastify-static@npm:4.4.2"
-  dependencies:
-    content-disposition: ^0.5.3
-    encoding-negotiator: ^2.0.1
-    fastify-plugin: ^3.0.0
-    glob: ^7.1.4
-    p-limit: ^3.1.0
-    readable-stream: ^3.4.0
-    send: ^0.17.1
-  checksum: 2b45049c54a6d9e28a55ac053d9ad8cffad92c6d8807844a2a9a39dcbd59b6094e4cb61ff5287917dc7736e6ab6755c5bd8ae21f7221469605a360689226859c
   languageName: node
   linkType: hard
 
@@ -9543,10 +9528,6 @@ __metadata:
     yargs: ^17.2.1
   peerDependencies:
     fastify: ^3.19.0
-    fastify-accepts: ^2.1.0
-    fastify-compress: ^3.6.0
-    fastify-plugin: ^3.0.0
-    fastify-static: ^4.2.0
     gatsby: ^4.0.0
   bin:
     gserve: ./cli.js
@@ -19461,9 +19442,6 @@ __metadata:
   dependencies:
     benchmark: ^2.1.4
     fastify: ^3.22.1
-    fastify-accepts: ^2.0.1
-    fastify-compress: ^3.6.1
-    fastify-static: ^4.4.2
     gatsby: ^4.0.0
     gatsby-plugin-fastify: "*"
     gatsby-plugin-image: ^2.0.0


### PR DESCRIPTION
## Description

Clean pre v1 for consistent client route naming and better docs. Fix incorrectly setting fastify plugins as peer deps. Move to standard dependencies also simplifies install process. 


### Documentation

done.
