### PR TITLE
chore(repo): update testing and node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 14.x
+      - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: "yarn"
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,33 +6,7 @@ on:
       - main
 
 jobs:
-  test:
-    name: Run package tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Build packages
-        run: yarn build
-
-      - name: Execute tests
-        run: yarn test
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
   release:
-    needs: test
     name: Package Version and Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: "yarn"
 
       - name: Install dependencies
@@ -26,14 +26,17 @@ jobs:
   test:
     name: Run package tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ["14", "16"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Set up Node.js
+      - name: Set up Node.js v${{ matrix.node }}
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
           cache: "yarn"
 
       - name: Install dependencies

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Format source code
         run: yarn lint
   test:
-    name: Run package tests
+    name: Run package tests (Node.js v${{ matrix.node }})
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION

## Description

Bumps node version used for actions to node v16 (current LTS). Bumps testing to use both active LTS versions.