### PR TITLE
feat(gatsby-plugin-fastify): Gatsby Reverse Proxy

### DIFF
--- a/.changeset/fluffy-walls-sniff.md
+++ b/.changeset/fluffy-walls-sniff.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": patch
+---
+
+Did some reworking of redirects and added support for Gatsby's new Reverse Proxy functionality.

--- a/integration-tests/plugin-fastify/benchmark.js
+++ b/integration-tests/plugin-fastify/benchmark.js
@@ -174,6 +174,17 @@ function expectResp(def, path, code = 200) {
           .then(expectResp(def, "/perm-redirect/", 301));
       },
     })
+    .add("Serve Reverse Proxy", {
+      defer: true,
+      fn: (def) => {
+        server
+          .inject({
+            method: "GET",
+            url: "/example-proxy/",
+          })
+          .then(expectResp(def, "/example-proxy/", 200));
+      },
+    })
     .add("Serve Function", {
       defer: true,
       fn: (def) => {

--- a/integration-tests/plugin-fastify/gatsby-node.js
+++ b/integration-tests/plugin-fastify/gatsby-node.js
@@ -73,4 +73,10 @@ exports.createPages = async (gatsbyUtilities) => {
     toPath: "/posts/page-3",
     statusCode: 307,
   });
+
+  createRedirect({
+    fromPath: "/example-proxy",
+    toPath: "http://example.com",
+    statusCode: 200,
+  });
 };

--- a/integration-tests/plugin-fastify/gatsby-node.js
+++ b/integration-tests/plugin-fastify/gatsby-node.js
@@ -79,4 +79,10 @@ exports.createPages = async (gatsbyUtilities) => {
     toPath: "http://example.com",
     statusCode: 200,
   });
+
+  createRedirect({
+    fromPath: "/example-proxy-star/*",
+    toPath: "http://example.com/*",
+    statusCode: 200,
+  });
 };

--- a/integration-tests/plugin-fastify/src/pages/index.js
+++ b/integration-tests/plugin-fastify/src/pages/index.js
@@ -120,6 +120,9 @@ const IndexPage = () => {
           <a href={withPrefix("/alt-redirect")}>To alt Redirect</a>
         </li>
         <li style={{ ...listItemStyles }}>
+          <a href={withPrefix("/example-proxy")}>To rev proxy</a>
+        </li>
+        <li style={{ ...listItemStyles }}>
           <a href={withPrefix("/generated/page-1")}>SSG via create page</a>
         </li>
         <li style={{ ...listItemStyles }}>

--- a/packages/gatsby-plugin-fastify/README.md
+++ b/packages/gatsby-plugin-fastify/README.md
@@ -48,8 +48,9 @@ module.exports = {
     /* Rest of the plugins */
     {
       resolve: `gatsby-plugin-fastify`,
-      /* Default option value shown */
-      options: { s },
+      options: {
+        /* discussed below */
+      }, // All options are optional
     },
   ],
 };
@@ -100,6 +101,29 @@ export GATSBY_SERVER_ADDRESS=0.0.0.0
 By default only basic info is logged along with warnings or errors. By setting the logging level to `debug` you'll also enable Fastify's default [request logging](https://www.fastify.io/docs/latest/Logging/) which is usually enabled for the `info` level.
 
 ## Features
+
+Some features can be disabled through the plugin options. This will not provide increased performance but is probided as an option to control features in certain deploys or to handoff certain features to an edge server or CDN as desired.
+
+```js
+module.exports = {
+  /* Site config */
+  plugins: [
+    /* Rest of the plugins */
+    {
+      resolve: `gatsby-plugin-fastify`,
+      /* Default option value shown */
+      options: {
+        features: {
+          redirects: true,
+          reverseProxy: true,
+        },
+      },
+    },
+  ],
+};
+```
+
+### Gatsby Reverse Proxy
 
 Building on top of the `createRedirects` API Gatsby Cloud now supports reverse proxies. We've implemented this feature here as well.
 

--- a/packages/gatsby-plugin-fastify/README.md
+++ b/packages/gatsby-plugin-fastify/README.md
@@ -26,6 +26,7 @@
 - Gatsby [404 page](https://www.gatsbyjs.com/docs/how-to/adding-common-features/add-404-page/)
 - Gatsby [500 page](https://www.gatsbyjs.com/docs/how-to/adding-common-features/add-500-page/)
 - Gatsby [redirects](https://www.gatsbyjs.com/docs/reference/config-files/actions/#createRedirect)
+- Gatsby [reverse proxy](https://support.gatsbyjs.com/hc/en-us/articles/1500003051241-Working-with-Redirects-and-Rewrites)
 - [Client-only routes](https://www.gatsbyjs.com/docs/how-to/routing/client-only-routes-and-user-authentication)
 - Serving the site with [pathPrefix](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/) - set it up inside `gatsby-config.js`, the plugin will take care of it
 - File compression, Etags, and more.
@@ -100,33 +101,22 @@ export GATSBY_SERVER_ADDRESS=0.0.0.0
 
 By default only basic info is logged along with warnings or errors. By setting the logging level to `debug` you'll also enable Fastify's default [request logging](https://www.fastify.io/docs/latest/Logging/) which is usually enabled for the `info` level.
 
-## Gatsby Fastify Plugin (advanced)
+## Features
 
-This plugin also implements a Fastify plugin for serving Gatsby. This may be imported via:
-
-```js
-import { serveGatsby } from "gatsby-plugin-fastify/plugins/gatsby";
-```
-
-For an example on how to use this, reference the server implementation file from [`src/serve.ts`](https://github.com/gatsby-uc/plugins/tree/main/packages/gatsby-plugin-fastify/src/serve.ts).
-
-## Gatsby Feature Fastify Plugins (expert)
-
-Finally, each of the Gatsby features (functions, static files, redirects, client-only routes, and 404 handling) is implemented in it's own plugin. Those may be imported as well for use in a custom server implementation.
+Building on top of the `createRedirects` API Gatsby Cloud now supports reverse proxies. We've implemented this feature here as well.
 
 ```js
-import { handle404 } from "gatsby-plugin-fastify/plugins/404";
-import { handle500 } from "gatsby-plugin-fastify/plugins/500";
-import { handleClientOnlyRoutes } from "gatsby-plugin-fastify/plugins/clientRoutes";
-import { handleFunctions } from "gatsby-plugin-fastify/plugins/functions";
-import { handleRedirects } from "gatsby-plugin-fastify/plugins/redirects";
-import { handleStatic } from "gatsby-plugin-fastify/plugins/static";
-import { handleServerRoutes } from "gatsby-plugin-fastify/plugins/serverRoutes";
+// gatsby-node.js
+createRedirect({
+  fromPath: `/docs/`,
+  toPath: `https://www.awesomesite.com/docs/`,
+  statusCode: 200,
+});
 ```
 
-For an example on how to use these, see the `serveGatsby` implementation file from [`src/plugins/gatsby.ts`](https://github.com/gatsby-uc/plugins/tree/main/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts).
+> The Gatsby docs note ending the to and from paths with `*`. This is not allowed in this plugin. If included they are stripped for compatibility.
 
-## Gatsby Functions
+### Gatsby Functions
 
 Gatsby's [function docs](https://www.gatsbyjs.com/docs/reference/functions/getting-started/) suggest that the `Request` and `Response` objects for your Gatsby functions will be _Express like_ and provide the types from the Gatsby core for these.
 
@@ -136,7 +126,9 @@ Because we're not using Express or Gatsby's own cloud offering functions will ne
 
 If you'd like to use Fastify with an _Express like_ API there are plugins for Fastify to do this, see their [docs on middleware](https://www.fastify.io/docs/latest/Reference/Middleware/). You'll need to use the exports provided in this package to write your own server implementation and add the correct plugins to support this.
 
-## TypeScript
+### Gatsby Reverse Proxy
+
+### TypeScript
 
 ```ts
 import type { FastifyRequest, FastifyReply } from "fastify";
@@ -145,3 +137,34 @@ export default function handler(req: FastifyRequest, res: FastifyReply) {
   res.send(`I am TYPESCRIPT`);
 }
 ```
+
+## Appendices
+
+### Appendix 1 - Alternative server usage
+
+#### Gatsby Fastify Plugin (advanced)
+
+This plugin also implements a Fastify plugin for serving Gatsby. This may be imported via:
+
+```js
+import { serveGatsby } from "gatsby-plugin-fastify/plugins/gatsby";
+```
+
+For an example on how to use this, reference the server implementation file from [`src/serve.ts`](https://github.com/gatsby-uc/plugins/tree/main/packages/gatsby-plugin-fastify/src/serve.ts).
+
+#### Gatsby Feature Fastify Plugins (expert)
+
+Finally, each of the Gatsby features (functions, static files, redirects, client-only routes, and 404 handling) is implemented in it's own plugin. Those may be imported as well for use in a custom server implementation.
+
+```js
+import { handle404 } from "gatsby-plugin-fastify/plugins/404";
+import { handle500 } from "gatsby-plugin-fastify/plugins/500";
+import { handleClientOnlyRoutes } from "gatsby-plugin-fastify/plugins/clientRoutes";
+import { handleFunctions } from "gatsby-plugin-fastify/plugins/functions";
+import { handleRedirects } from "gatsby-plugin-fastify/plugins/redirects";
+import { handleReverseProxy } from "gatsby-plugin-fastify/plugins/reverseProxy";
+import { handleStatic } from "gatsby-plugin-fastify/plugins/static";
+import { handleServerRoutes } from "gatsby-plugin-fastify/plugins/serverRoutes";
+```
+
+For an example on how to use these, see the `serveGatsby` implementation file from [`src/plugins/gatsby.ts`](https://github.com/gatsby-uc/plugins/tree/main/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts).

--- a/packages/gatsby-plugin-fastify/README.md
+++ b/packages/gatsby-plugin-fastify/README.md
@@ -132,7 +132,7 @@ Building on top of the `createRedirects` API Gatsby Cloud now supports reverse p
 createRedirect({
   fromPath: `/docs/`,
   toPath: `https://www.awesomesite.com/docs/`,
-  statusCode: 200,
+  statusCode: 200, // The 200 is required to denote a proxy response as opposed to a redirect
 });
 ```
 
@@ -145,10 +145,6 @@ Gatsby's [function docs](https://www.gatsbyjs.com/docs/reference/functions/getti
 > **THIS IS NOT TRUE FOR THIS PLUGIN**
 
 Because we're not using Express or Gatsby's own cloud offering functions will need to use Fastify's own [`Request`](https://www.fastify.io/docs/latest/Reference/Request/) and [`Reply`](https://www.fastify.io/docs/latest/Reference/Reply/) API.
-
-If you'd like to use Fastify with an _Express like_ API there are plugins for Fastify to do this, see their [docs on middleware](https://www.fastify.io/docs/latest/Reference/Middleware/). You'll need to use the exports provided in this package to write your own server implementation and add the correct plugins to support this.
-
-### Gatsby Reverse Proxy
 
 ### TypeScript
 

--- a/packages/gatsby-plugin-fastify/package.json
+++ b/packages/gatsby-plugin-fastify/package.json
@@ -37,6 +37,7 @@
     "fastify-plugin": "^3.0.1",
     "fastify-static": "^4.5.0",
     "fs-extra": "^10.0.1",
+    "http-status-codes": "^2.2.0",
     "open": "^8.4.0",
     "picomatch": "^2.3.1",
     "pino-pretty": "^7.5.1",

--- a/packages/gatsby-plugin-fastify/package.json
+++ b/packages/gatsby-plugin-fastify/package.json
@@ -34,6 +34,7 @@
     "@babel/runtime": "^7.17.2",
     "fastify-accepts": "^2.1.0",
     "fastify-compress": "^3.7.0",
+    "fastify-http-proxy": "^6.2.2",
     "fastify-plugin": "^3.0.1",
     "fastify-static": "^4.5.0",
     "fs-extra": "^10.0.1",

--- a/packages/gatsby-plugin-fastify/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-fastify/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -28,6 +28,7 @@ Object {
     },
   ],
   "prefix": "/test",
+  "proxies": Array [],
   "redirects": Array [
     Object {
       "fromPath": "/perm-redirect",

--- a/packages/gatsby-plugin-fastify/src/__tests__/plugins/reverseProxy.js
+++ b/packages/gatsby-plugin-fastify/src/__tests__/plugins/reverseProxy.js
@@ -1,0 +1,68 @@
+const { serveGatsby } = require("../../plugins/gatsby");
+
+const { ConfigKeyEnum, setConfig, getServerConfig } = require("../../utils/config");
+
+const { createCliConfig, createFastifyInstance } = require("../__utils__/config");
+
+jest.mock("../../utils/constants", () => ({
+  ...jest.requireActual("../../utils/constants"),
+  PATH_TO_FUNCTIONS: "../../integration-tests/plugin-fastify/.cache/functions/",
+  PATH_TO_PUBLIC: "src/__tests__/__files__/public",
+  PATH_TO_CACHE: "../../integration-tests/plugin-fastify/.cache",
+  CONFIG_FILE_PATH: "../../integration-tests/plugin-fastify/.cache",
+}));
+
+describe(`Test Gatsby Reverse Proxy Routes`, () => {
+  beforeAll(() => {
+    setConfig(
+      ConfigKeyEnum.CLI,
+      createCliConfig({
+        port: 3000,
+        host: "127.0.0.1",
+        logLevel: "fatal",
+        open: false,
+      })
+    );
+
+    setConfig(ConfigKeyEnum.SERVER, getServerConfig());
+  });
+
+  it(`Should serve Reverse Proxy route`, async () => {
+    const fastify = await createFastifyInstance(serveGatsby);
+
+    const response = await fastify.inject({
+      url: "/example-proxy/",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.headers["x-gatsby-fastify"]).toContain("Reverse Proxy");
+    expect(response.payload).toContain("Example Domain");
+  });
+
+  it(`Should serve Reverse Proxy route made with trailing *`, async () => {
+    const fastify = await createFastifyInstance(serveGatsby);
+
+    const response = await fastify.inject({
+      url: "/example-proxy-star/",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.headers["x-gatsby-fastify"]).toContain("Reverse Proxy");
+    expect(response.payload).toContain("Example Domain");
+  });
+
+  it(`Should not serve Reverse Proxy route made with trailing * at *`, async () => {
+    const fastify = await createFastifyInstance(serveGatsby);
+
+    const response = await fastify.inject({
+      url: "/example-proxy-star/*",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/packages/gatsby-plugin-fastify/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-fastify/src/gatsby-node.ts
@@ -45,6 +45,6 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }) 
     compression: Joi.boolean().default(true),
     features: Joi.object({
       reverseProxy: Joi.alternatives().try(Joi.boolean(), Joi.object()).default(true),
-    }),
+    }).default(),
   });
 };

--- a/packages/gatsby-plugin-fastify/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-fastify/src/gatsby-node.ts
@@ -44,6 +44,7 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }) 
   return Joi.object({
     features: Joi.object({
       reverseProxy: Joi.alternatives().try(Joi.boolean(), Joi.object()).default(true),
+      redirects: Joi.boolean().default(true),
     }).default(),
   });
 };

--- a/packages/gatsby-plugin-fastify/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-fastify/src/gatsby-node.ts
@@ -1,5 +1,5 @@
 import { writeJSON } from "fs-extra";
-import type { GatsbyNodeServerConfig } from "./utils/config";
+import type { GatsbyFastifyPluginOptions, GatsbyNodeServerConfig } from "./utils/config";
 import type { GatsbyNode } from "gatsby";
 
 import { makePluginData } from "./utils/plugin-data";
@@ -11,7 +11,7 @@ import { getProxiesAndRedirects } from "./gatsby/proxiesAndRedirects";
 
 export const onPostBuild: GatsbyNode["onPostBuild"] = async (
   { store, pathPrefix, reporter },
-  pluginOptions: GatsbyNodeServerConfig
+  pluginOptions: GatsbyFastifyPluginOptions
 ) => {
   try {
     const { proxies, redirects } = getProxiesAndRedirects(store);

--- a/packages/gatsby-plugin-fastify/src/gatsby/proxiesAndRedirects.ts
+++ b/packages/gatsby-plugin-fastify/src/gatsby/proxiesAndRedirects.ts
@@ -1,0 +1,23 @@
+import { IRedirect } from "gatsby/dist/redux/types";
+
+export type GatsbyFastifyProxy = { toPath: string; fromPath: string };
+
+export function getProxiesAndRedirects(store) {
+  const { redirects: proxiesAndRedirects } = store.getState();
+
+  return proxiesAndRedirects.reduce(
+    (acc, curr) => {
+      if (curr.statusCode == 200) {
+        acc.proxies.push({
+          toPath: curr.toPath.replace(/\*$/, ""),
+          fromPath: curr.fromPath.replace(/\*$/, ""),
+        });
+      } else {
+        acc.redirects.push(curr);
+      }
+
+      return acc;
+    },
+    { redirects: [] as IRedirect[], proxies: [] as GatsbyFastifyProxy[] }
+  );
+}

--- a/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
@@ -38,7 +38,9 @@ export const serveGatsby: FastifyPluginAsync = async (fastify) => {
   });
 
   // Gatsby Redirects
-  await fastify.register(handleRedirects, { redirects });
+  if (features?.redirects) {
+    await fastify.register(handleRedirects, { redirects });
+  }
 
   // Gatsby Reverse Proxy
   if (features?.reverseProxy) {

--- a/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
@@ -41,7 +41,7 @@ export const serveGatsby: FastifyPluginAsync = async (fastify) => {
   await fastify.register(handleRedirects, { redirects });
 
   // Gatsby Reverse Proxy
-  if (features.reverseProxy) {
+  if (features?.reverseProxy) {
     await fastify.register(handleReverseProxy, { proxies });
   }
 

--- a/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
@@ -1,6 +1,7 @@
 import { handleClientOnlyRoutes } from "./clientRoutes";
 import { handleFunctions } from "./functions";
 import { handleRedirects } from "./redirects";
+import { handleReverseProxy } from "./reverseProxy";
 import { handleStatic } from "./static";
 import { handleServerRoutes } from "./serverRoutes";
 import { handle404 } from "./404";
@@ -14,7 +15,15 @@ import type { FastifyPluginAsync } from "fastify";
 export const serveGatsby: FastifyPluginAsync = async (fastify) => {
   const { server: serverConfig } = getConfig();
 
-  const { clientSideRoutes, serverSideRoutes, redirects, compression, functions } = serverConfig;
+  const {
+    clientSideRoutes,
+    serverSideRoutes,
+    redirects,
+    compression,
+    functions,
+    proxies,
+    features,
+  } = serverConfig;
 
   // Utils
   fastify.register(fastifyAccepts);
@@ -44,6 +53,11 @@ export const serveGatsby: FastifyPluginAsync = async (fastify) => {
 
   // Gatsby Redirects
   await fastify.register(handleRedirects, { redirects });
+
+  // Gatsby Reverse Proxy
+  if (features.reverseProxy) {
+    await fastify.register(handleReverseProxy, { proxies });
+  }
 
   // Gatsby DSG & SSR
   await fastify.register(handleServerRoutes, { paths: serverSideRoutes });

--- a/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/gatsby.ts
@@ -42,11 +42,15 @@ export const serveGatsby: FastifyPluginAsync = async (fastify) => {
   // Gatsby Redirects
   if (features?.redirects) {
     await fastify.register(handleRedirects, { redirects });
+  } else {
+    fastify.log.warn("Redirects disabled.");
   }
 
   // Gatsby Reverse Proxy
   if (features?.reverseProxy) {
     await fastify.register(handleReverseProxy, { proxies });
+  } else {
+    fastify.log.warn("Reverse proxy disabled.");
   }
 
   // Gatsby DSG & SSR

--- a/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
@@ -1,4 +1,3 @@
-import pluginHttpProxy from "fastify-http-proxy";
 import { StatusCodes } from "http-status-codes";
 
 import type { FastifyPluginAsync } from "fastify";

--- a/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
@@ -13,8 +13,14 @@ export function getResponseCode(redirect: IRedirect): StatusCodes {
 export const handleRedirects: FastifyPluginAsync<{
   redirects: IRedirect[];
 }> = async (fastify, { redirects }) => {
+  fastify.log.info(`Registering ${redirects.length} redirect(s)`);
+
   for (const redirect of redirects) {
     const responseCode = getResponseCode(redirect);
+    fastify.log.debug(
+      `Registering "${redirect.fromPath}" as redirect to "${redirect.toPath}" with HTTP status code "${responseCode}".`
+    );
+
     fastify.get(redirect.fromPath, (_req, reply) => {
       reply.code(responseCode).redirect(redirect.toPath);
     });

--- a/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
@@ -1,10 +1,13 @@
-import { IRedirect } from "gatsby/dist/redux/types";
-import { FastifyPluginAsync } from "fastify";
+import pluginHttpProxy from "fastify-http-proxy";
+import { StatusCodes } from "http-status-codes";
 
-export function getResponseCode(redirect: IRedirect): HttpRedirectCodes {
+import type { FastifyPluginAsync } from "fastify";
+import type { IRedirect } from "gatsby/dist/redux/types";
+
+export function getResponseCode(redirect: IRedirect): StatusCodes {
   return (
     redirect.statusCode ||
-    (redirect.isPermanent ? HttpRedirectCodes.MovedPermanently : HttpRedirectCodes.Found)
+    (redirect.isPermanent ? StatusCodes.MOVED_PERMANENTLY : StatusCodes.MOVED_TEMPORARILY)
   );
 }
 
@@ -18,14 +21,3 @@ export const handleRedirects: FastifyPluginAsync<{
     });
   }
 };
-enum HttpRedirectCodes {
-  MultipleChoices = 300,
-  MovedPermanently = 301,
-  Found = 302,
-  SeeOther = 303,
-  NotModified = 304,
-  UseProxy = 305,
-  SwitchProxy = 306,
-  TemporaryRedirect = 307,
-  PermanentRedirect = 308,
-}

--- a/packages/gatsby-plugin-fastify/src/plugins/reverseProxy.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/reverseProxy.ts
@@ -1,6 +1,6 @@
 import pluginHttpProxy from "fastify-http-proxy";
 
-import type { FastifyPluginAsync } from "fastify";
+import type { FastifyPluginAsync, FastifyReply } from "fastify";
 import type { GatsbyFastifyProxy } from "../gatsby/proxiesAndRedirects";
 
 // Implements https://support.gatsbsyjs.com/hc/en-us/articles/1500003051241-Working-with-Redirects-and-Rewrites
@@ -19,7 +19,7 @@ export const handleReverseProxy: FastifyPluginAsync<{
         prefix: proxy.fromPath,
         replyOptions: {
           onResponse: (_req, reply, res) => {
-            reply.header("x-gatsby-fastify", "served-by: reverse-proxy-handler");
+            (reply as FastifyReply).appendModuleHeader("Reverse Proxy");
             reply.send(res);
           },
         },

--- a/packages/gatsby-plugin-fastify/src/plugins/reverseProxy.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/reverseProxy.ts
@@ -11,12 +11,17 @@ export const handleReverseProxy: FastifyPluginAsync<{
 
   for (const proxy of proxies) {
     try {
-      const proxyTo = new URL(proxy.toPath);
-      fastify.log.debug(`Registering "${proxy.fromPath}" as proxied route to "${proxy.toPath}".`);
+      // Fastify doesn't not support/require the trailing "*" in the path, so we need to remove if they exist
+      const cleanTo = proxy.toPath.replace(/\*$/, "");
+      const cleanFrom = proxy.fromPath.replace(/\*$/, "");
+
+      const proxyTo = new URL(cleanTo);
+
+      fastify.log.debug(`Registering "${cleanFrom}" as proxied route to "${cleanTo}".`);
 
       fastify.register(pluginHttpProxy, {
         upstream: proxyTo.href,
-        prefix: proxy.fromPath,
+        prefix: cleanFrom,
         replyOptions: {
           onResponse: (_req, reply, res) => {
             (reply as FastifyReply).appendModuleHeader("Reverse Proxy");

--- a/packages/gatsby-plugin-fastify/src/plugins/reverseProxy.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/reverseProxy.ts
@@ -1,0 +1,28 @@
+import pluginHttpProxy from "fastify-http-proxy";
+
+import type { FastifyPluginAsync } from "fastify";
+import type { GatsbyFastifyProxy } from "../gatsby/proxiesAndRedirects";
+
+// Implements https://support.gatsbsyjs.com/hc/en-us/articles/1500003051241-Working-with-Redirects-and-Rewrites
+export const handleReverseProxy: FastifyPluginAsync<{
+  proxies: GatsbyFastifyProxy[];
+}> = async (fastify, { proxies }) => {
+  for (const proxy of proxies) {
+    try {
+      const proxyTo = new URL(proxy.toPath);
+
+      fastify.register(pluginHttpProxy, {
+        upstream: proxyTo.href,
+        prefix: proxy.fromPath,
+        replyOptions: {
+          onResponse: (_req, reply, res) => {
+            reply.header("x-gatsby-fastify", "served-by: reverse-proxy-handler");
+            reply.send(res);
+          },
+        },
+      });
+    } catch (e) {
+      fastify.log.error(e);
+    }
+  }
+};

--- a/packages/gatsby-plugin-fastify/src/plugins/reverseProxy.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/reverseProxy.ts
@@ -7,9 +7,12 @@ import type { GatsbyFastifyProxy } from "../gatsby/proxiesAndRedirects";
 export const handleReverseProxy: FastifyPluginAsync<{
   proxies: GatsbyFastifyProxy[];
 }> = async (fastify, { proxies }) => {
+  fastify.log.info(`Registering ${proxies.length} reverse proxy route(s)`);
+
   for (const proxy of proxies) {
     try {
       const proxyTo = new URL(proxy.toPath);
+      fastify.log.debug(`Registering "${proxy.fromPath}" as proxied route to "${proxy.toPath}".`);
 
       fastify.register(pluginHttpProxy, {
         upstream: proxyTo.href,

--- a/packages/gatsby-plugin-fastify/src/utils/config.ts
+++ b/packages/gatsby-plugin-fastify/src/utils/config.ts
@@ -17,6 +17,7 @@ const configPrefixer = buildPrefixer(CONFIG_FILE_PATH);
 export interface GatsbyFastifyPluginOptions extends PluginOptions {
   features: {
     reverseProxy: boolean | {};
+    redirects: boolean;
   };
 }
 export interface GatsbyNodeServerConfig extends GatsbyFastifyPluginOptions {

--- a/packages/gatsby-plugin-fastify/src/utils/config.ts
+++ b/packages/gatsby-plugin-fastify/src/utils/config.ts
@@ -4,6 +4,7 @@ import type { NoUndefinedField } from "../gatsby/clientSideRoutes";
 import type { IGatsbyFunction, IRedirect } from "gatsby/dist/redux/types";
 import type { PluginOptions } from "gatsby";
 import type { ServerSideRoute } from "../gatsby/serverRoutes";
+import type { GatsbyFastifyProxy } from "../gatsby/proxiesAndRedirects";
 
 import { PathConfig } from "../plugins/clientRoutes";
 import { CONFIG_FILE_NAME, CONFIG_FILE_PATH } from "./constants";
@@ -20,6 +21,10 @@ export interface GatsbyNodeServerConfig extends PluginOptions {
   prefix: string | undefined;
   functions: IGatsbyFunction[];
   compression: boolean;
+  proxies: GatsbyFastifyProxy[];
+  features: {
+    reverseProxy: boolean | {};
+  };
 }
 
 export type GfCliOptions = {

--- a/packages/gatsby-plugin-fastify/src/utils/config.ts
+++ b/packages/gatsby-plugin-fastify/src/utils/config.ts
@@ -14,16 +14,18 @@ let config: Partial<GfConfig> = {};
 
 const configPrefixer = buildPrefixer(CONFIG_FILE_PATH);
 
-export interface GatsbyNodeServerConfig extends PluginOptions {
+export interface GatsbyFastifyPluginOptions extends PluginOptions {
+  features: {
+    reverseProxy: boolean | {};
+  };
+}
+export interface GatsbyNodeServerConfig extends GatsbyFastifyPluginOptions {
   clientSideRoutes: NoUndefinedField<PathConfig>[];
   serverSideRoutes: ServerSideRoute[];
   redirects: IRedirect[];
   prefix: string | undefined;
   functions: IGatsbyFunction[];
   proxies: GatsbyFastifyProxy[];
-  features: {
-    reverseProxy: boolean | {};
-  };
 }
 
 export type GfCliOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8492,6 +8492,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"depd@npm:2.0.0":
+  version: 2.0.0
+  resolution: "depd@npm:2.0.0"
+  checksum: abbe19c768c97ee2eed6282d8ce3031126662252c58d711f646921c9623f9052e3e1906443066beec1095832f534e57c523b7333f8e7e0d93051ab6baef5ab3a
+  languageName: node
+  linkType: hard
+
 "depd@npm:^1.1.2, depd@npm:~1.1.2":
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
@@ -8920,7 +8927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.0.0, end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
+"end-of-stream@npm:^1.0.0, end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1, end-of-stream@npm:^1.4.4":
   version: 1.4.4
   resolution: "end-of-stream@npm:1.4.4"
   dependencies:
@@ -10158,6 +10165,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fastify-http-proxy@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "fastify-http-proxy@npm:6.2.2"
+  dependencies:
+    fastify-reply-from: ^6.4.1
+    ws: ^8.4.2
+  checksum: c95c8050354f82309069f2468a302267cba0661a602785bbb2b9e962512dce219349cbbf746db4b600897540677b9bd707c2b31c2b5727c4a786e91ff10eff25
+  languageName: node
+  linkType: hard
+
 "fastify-plugin@npm:^3.0.0":
   version: 3.0.0
   resolution: "fastify-plugin@npm:3.0.0"
@@ -10169,6 +10186,21 @@ __metadata:
   version: 3.0.1
   resolution: "fastify-plugin@npm:3.0.1"
   checksum: 131ba0a388f777829c3fb0fd5b75cf057688ce6d0ca354fb1ebf829767a8c853b0825762b9185b5200097454df0ede2f3095da2efe1aa1b3736d07f194e6d374
+  languageName: node
+  linkType: hard
+
+"fastify-reply-from@npm:^6.4.1":
+  version: 6.5.0
+  resolution: "fastify-reply-from@npm:6.5.0"
+  dependencies:
+    end-of-stream: ^1.4.4
+    fastify-plugin: ^3.0.0
+    http-errors: ^2.0.0
+    pump: ^3.0.0
+    semver: ^7.3.5
+    tiny-lru: ^8.0.1
+    undici: ^4.0.0
+  checksum: 27d0b2b019f5834ba089046b6a12e390557f00f61f0e3fb178ea8bb7c3c1d161b34fb2dae136d4d2817e04a285cb1912db5cb3ffb3d13c57ee87950a3900f7f9
   languageName: node
   linkType: hard
 
@@ -11179,6 +11211,7 @@ __metadata:
     fastify: ^3.27.2
     fastify-accepts: ^2.1.0
     fastify-compress: ^3.7.0
+    fastify-http-proxy: ^6.2.2
     fastify-plugin: ^3.0.1
     fastify-static: ^4.5.0
     fs-extra: ^10.0.1
@@ -13057,6 +13090,19 @@ __metadata:
     statuses: ">= 1.5.0 < 2"
     toidentifier: 1.0.0
   checksum: 873d997bada0340b31cc69cbe8376e47ee142f60375b81447fa3ad7be512dd4026afb3b46ed2257ee59472d43782a34151994b34264b204bcaad02e67ad836cb
+  languageName: node
+  linkType: hard
+
+"http-errors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "http-errors@npm:2.0.0"
+  dependencies:
+    depd: 2.0.0
+    inherits: 2.0.4
+    setprototypeof: 1.2.0
+    statuses: 2.0.1
+    toidentifier: 1.0.1
+  checksum: 9b0a3782665c52ce9dc658a0d1560bcb0214ba5699e4ea15aefb2a496e2ca83db03ebc42e1cce4ac1f413e4e0d2d736a3fd755772c556a9a06853ba2a0b7d920
   languageName: node
   linkType: hard
 
@@ -20091,6 +20137,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"statuses@npm:2.0.1":
+  version: 2.0.1
+  resolution: "statuses@npm:2.0.1"
+  checksum: 18c7623fdb8f646fb213ca4051be4df7efb3484d4ab662937ca6fbef7ced9b9e12842709872eb3020cc3504b93bde88935c9f6417489627a7786f24f8031cbcb
+  languageName: node
+  linkType: hard
+
 "statuses@npm:>= 1.5.0 < 2, statuses@npm:~1.5.0":
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
@@ -20893,6 +20946,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"toidentifier@npm:1.0.1":
+  version: 1.0.1
+  resolution: "toidentifier@npm:1.0.1"
+  checksum: 952c29e2a85d7123239b5cfdd889a0dde47ab0497f0913d70588f19c53f7e0b5327c95f4651e413c74b785147f9637b17410ac8c846d5d4a20a5a33eb6dc3a45
+  languageName: node
+  linkType: hard
+
 "token-types@npm:^4.1.1":
   version: 4.1.1
   resolution: "token-types@npm:4.1.1"
@@ -21256,6 +21316,13 @@ __metadata:
   version: 0.1.2
   resolution: "unc-path-regex@npm:0.1.2"
   checksum: a05fa2006bf4606051c10fc7968f08ce7b28fa646befafa282813aeb1ac1a56f65cb1b577ca7851af2726198d59475bb49b11776036257b843eaacee2860a4ec
+  languageName: node
+  linkType: hard
+
+"undici@npm:^4.0.0":
+  version: 4.15.1
+  resolution: "undici@npm:4.15.1"
+  checksum: 13b264d4966de105e211e1ca9433e2d8be5fcfe85e4cafea6b97c4685df3364bc8bc9e9b27796ce400e8a1e45e92a65b1453fcb499557e4f5c013af18f194852
   languageName: node
   linkType: hard
 
@@ -22061,6 +22128,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: bd2b437256012af526c69c03d6670a132e7ab0fe5853f3b7092826acea4203fad4ee2a8d0d9bd44834b2b968e747bf34f753ab535f4a3edf40d262da4b1d0805
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.4.2":
+  version: 8.5.0
+  resolution: "ws@npm:8.5.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 76f2f90e40344bf18fd544194e7067812fb1372b2a37865678d8f12afe4b478ff2ebc0c7c0aff82cd5e6b66fc43d889eec0f1865c2365d8f7a66d92da7744a77
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11184,6 +11184,7 @@ __metadata:
     fs-extra: ^10.0.1
     gatsby: ^4.8.1
     gatsby-plugin-utils: ^3.2.0
+    http-status-codes: ^2.2.0
     jest: ^27.5.1
     open: ^8.4.0
     picomatch: ^2.3.1
@@ -13100,6 +13101,13 @@ __metadata:
     jsprim: ^2.0.2
     sshpk: ^1.14.1
   checksum: 10be2af4764e71fee0281392937050201ee576ac755c543f570d6d87134ce5e858663fe999a7adb3e4e368e1e356d0d7fec6b9542295b875726ff615188e7a0c
+  languageName: node
+  linkType: hard
+
+"http-status-codes@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "http-status-codes@npm:2.2.0"
+  checksum: 31e1d730856210445da0907d9b484629e69e4fe92ac032478a7aa4d89e5b215e2b4e75d7ebce40d0537b6850bd281b2f65c7cc36cc2677e5de056d6cea1045ce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Builds on top of `createRedirects` to implement a reverse proxy on specified routes like Gatsby recently did for Gatsby Cloud. 

### TBD

- [x] Tests
- [x] Edge case handling?

### Documentation
Yup

## Related Issues

closes #196 

