### PR TITLE
fix(gatsby-plugin-github-ribbon): move react to peer dep

### DIFF
--- a/.changeset/six-lies-whisper.md
+++ b/.changeset/six-lies-whisper.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-github-ribbon": minor
+---
+
+`react` and `react-dom` are moved to peerdeps as they should have been. Non-breaking cause all gatsby projects will already have these deps.

--- a/packages/gatsby-plugin-github-ribbon/package.json
+++ b/packages/gatsby-plugin-github-ribbon/package.json
@@ -26,7 +26,9 @@
     "watch": "yarn build --watch"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "react": "*",
+    "react-dom": "*"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.10",
@@ -35,9 +37,7 @@
     "babel-preset-gatsby-package": "^2.22.0",
     "cross-env": "^7.0.3",
     "gatsby": "^4.22.0",
-    "jest": "^27.5.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "jest": "^27.5.1"
   },
   "dependencies": {
     "request": "^2.88.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11020,11 +11020,11 @@ __metadata:
     cross-env: ^7.0.3
     gatsby: ^4.22.0
     jest: ^27.5.1
-    react: ^17.0.2
-    react-dom: ^17.0.2
     request: ^2.88.2
   peerDependencies:
     gatsby: ^2.0.0 || ^3.0.0 || ^4.0.0
+    react: "*"
+    react-dom: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION

## Description

move react to peer deps as it should be

### Documentation
yup

## Related 

none