### PR TITLE
feat(gatsby-plugin-fastify): use match paths in ssr to support SSR based client routes 

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -99,6 +99,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "klyngen",
+      "name": "Martin Klingenberg",
+      "avatar_url": "https://avatars.githubusercontent.com/u/14232560?v=4",
+      "profile": "https://github.com/klyngen",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.changeset/tender-snails-stare.md
+++ b/.changeset/tender-snails-stare.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": patch
+---
+
+Fallback routes get SSR-support

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 <p align="center">
   <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 </p>
 
@@ -56,6 +56,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://github.com/alan2207"><img src="https://avatars.githubusercontent.com/u/12713315?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alan Alickovic</b></sub></a><br /><a href="https://github.com/gatsby-uc/plugins/commits?author=alan2207" title="Documentation">📖</a> <a href="#plugin-alan2207" title="Plugin/utility libraries">🔌</a></td>
     <td align="center"><a href="https://github.com/mattcompiles"><img src="https://avatars.githubusercontent.com/u/8802980?v=4?s=100" width="100px;" alt=""/><br /><sub><b>mattcompiles</b></sub></a><br /><a href="https://github.com/gatsby-uc/plugins/commits?author=mattcompiles" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/klyngen"><img src="https://avatars.githubusercontent.com/u/14232560?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Martin Klingenberg</b></sub></a><br /><a href="https://github.com/gatsby-uc/plugins/commits?author=klyngen" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/integration-tests/plugin-fastify/src/pages/index.js
+++ b/integration-tests/plugin-fastify/src/pages/index.js
@@ -140,6 +140,12 @@ const IndexPage = () => {
         <li style={{ ...listItemStyles }}>
           <a href={withPrefix("/ssr403")}>Unauthorized SSR Page</a>
         </li>
+        <li style={{ ...listItemStyles }}>
+          <a href={withPrefix("/ssr/43")}>Dynamicly routed SSR page (slug is 43)</a>
+        </li>
+        <li style={{ ...listItemStyles }}>
+          <a href={withPrefix("/ssr/42")}>Dynamicly routed SSR page (slug is 42)</a>
+        </li>
       </ul>
     </main>
   );

--- a/integration-tests/plugin-fastify/src/pages/ssr/[slug].js
+++ b/integration-tests/plugin-fastify/src/pages/ssr/[slug].js
@@ -1,0 +1,13 @@
+import * as React from "react";
+export default function SsrFallBackExample({ serverData }) {
+  return <main>{serverData.message}</main>;
+}
+
+export async function getServerData({ params }) {
+  return {
+    status: 200,
+    props: {
+      message: params["slug"] === "42" ? "meaning of life" : "try again",
+    },
+  };
+}

--- a/packages/gatsby-plugin-fastify/src/__tests__/plugins/serverRoutes.js
+++ b/packages/gatsby-plugin-fastify/src/__tests__/plugins/serverRoutes.js
@@ -141,6 +141,26 @@ describe(`Test Gatsby DSG/SSR Routes`, () => {
       expect(response.headers["x-test"]).toEqual("Custom Headers Work!");
       expect(response.payload).toContain("SSR Page with Dogs");
     });
+
+    it(`Should serve SSR page from a fallbackRoute`, async () => {
+      const meaningfulResponse = await globalFastify.inject({
+        url: "/ssr/42",
+        method: "GET",
+      });
+
+      expect(meaningfulResponse.statusCode).toEqual(200);
+      expect(meaningfulResponse.headers["x-gatsby-fastify"]).toContain("SSR");
+      expect(meaningfulResponse.payload).toContain("meaning of life");
+
+      const meaninglessResponse = await globalFastify.inject({
+        url: "/ssr/43",
+        method: "GET",
+      });
+
+      expect(meaninglessResponse.statusCode).toEqual(200);
+      expect(meaninglessResponse.headers["x-gatsby-fastify"]).toContain("SSR");
+      expect(meaninglessResponse.payload).toContain("try again");
+    });
   });
 
   it(`Should 400 if request does not accept "text/html" on DSG/SSR route`, async () => {

--- a/packages/gatsby-plugin-fastify/src/gatsby/clientSideRoutes.ts
+++ b/packages/gatsby-plugin-fastify/src/gatsby/clientSideRoutes.ts
@@ -9,7 +9,7 @@ export async function getClientSideRoutes(pageData: PluginData) {
   const routes: NoUndefinedField<PathConfig>[] = [];
 
   for (const page of pages.values()) {
-    if (page?.matchPath) {
+    if (page?.matchPath && page?.mode !== "SSR" && page?.mode !== "DSG") {
       routes.push({
         matchPath: page.matchPath,
         path: page.path,

--- a/packages/gatsby-plugin-fastify/src/gatsby/serverRoutes.ts
+++ b/packages/gatsby-plugin-fastify/src/gatsby/serverRoutes.ts
@@ -1,17 +1,18 @@
 import type { PluginData } from "../utils/plugin-data";
+import { formatMatchPath } from "../utils/routes";
 
 export type ServerSideRoute = { path: string; mode: "DSG" | "SSR" };
 
 export async function getServerSideRoutes(pageData: PluginData) {
   const { pages } = pageData;
-
   const routes: ServerSideRoute[] = [];
 
   for (const page of pages.values()) {
     if (page?.mode === "DSG" || page?.mode === "SSR") {
-      const { path, mode } = page;
+      const { path, mode, matchPath } = page;
+
       routes.push({
-        path,
+        path: formatMatchPath(matchPath) ?? path,
         mode,
       });
     }

--- a/packages/gatsby-plugin-fastify/src/plugins/clientRoutes.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/clientRoutes.ts
@@ -4,6 +4,7 @@ import { PATH_TO_PUBLIC } from "../utils/constants";
 
 import type { FastifyPluginAsync } from "fastify";
 import type { NoUndefinedField } from "../gatsby/clientSideRoutes";
+import { formatMatchPath } from "../utils/routes";
 
 export type PathConfig = {
   matchPath: string | undefined;
@@ -19,13 +20,7 @@ export const handleClientOnlyRoutes: FastifyPluginAsync<{
     for (const p of paths) {
       fastify.log.debug(`Registering client-only route: ${p.path}`);
 
-      // This code only works because I've editted the fastify-static implementation to not encodeURI on file names. https://github.com/fastify/fastify-static/issues/234
-      // Work around for https://github.com/fastify/fastify/issues/3331
-      // Update, SSR/DSG was implemented without wildcard so this was not an issue. In the future we may need to change this back if we revert to not wildcarding static routes.
-      // not sure what cahnged with fastify v4 but it seems we had to switch static to not do wild card to get basic routes to not do infinit redirects.
-      const fastifyMatchPath = p.matchPath.replace(/\/\*$/, "*");
-
-      fastify.get(fastifyMatchPath, (_req, reply) => {
+      fastify.get(formatMatchPath(p.matchPath), (_req, reply) => {
         reply.appendModuleHeader("Client Route");
 
         reply.sendFile("index.html", resolve(PATH_TO_PUBLIC, p.path.replace("/", "")));

--- a/packages/gatsby-plugin-fastify/src/utils/routes.ts
+++ b/packages/gatsby-plugin-fastify/src/utils/routes.ts
@@ -1,0 +1,10 @@
+// This code only works because I've editted the fastify-static implementation to not encodeURI on file names. https://github.com/fastify/fastify-static/issues/234
+// Work around for https://github.com/fastify/fastify/issues/3331
+// Update, SSR/DSG was implemented without wildcard so this was not an issue. In the future we may need to change this back if we revert to not wildcarding static routes.
+// not sure what cahnged with fastify v4 but it seems we had to switch static to not do wild card to get basic routes to not do infinit redirects.
+export function formatMatchPath(matchPath?: string): string | null {
+  if (matchPath === undefined) {
+    return null;
+  }
+  return matchPath.replace(/\/\*$/, "*");
+}


### PR DESCRIPTION
## Description
The goal is to have fallback-routes working as in gatsby cloud.

#### Change 1:
When a route is of type SSR or DSG, it will not be registered as a clientRoute

#### Change 2:
Trying to use matchPath and not path for SSR. If not done like that, the routes will not be mounted correctly

### Documentation

Documentation. No but I have this webpage using my modified version. [Alv.no](https://alv.no)


closes #215