### PR TITLE
BREAKING(gatsby-plugin-vanilla-extract): Remove Babel plugin & bump webpack peerDep

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -90,6 +90,15 @@
         "doc",
         "plugin"
       ]
+    },
+    {
+      "login": "mattcompiles",
+      "name": "mattcompiles",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8802980?v=4",
+      "profile": "https://github.com/mattcompiles",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.changeset/cyan-balloons-kiss.md
+++ b/.changeset/cyan-balloons-kiss.md
@@ -1,0 +1,9 @@
+---
+"gatsby-plugin-vanilla-extract": major
+---
+
+Remove `@vanilla-extract/babel-plugin` from plugin
+
+BREAKING CHANGE
+
+As of `@vanilla-extract/webpack-plugin@v2.2.0` the babel plugin is no longer required. Therefore the peer dependency range has been updated to `^2.2.0`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 <p align="center">
   <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 </p>
 
@@ -55,6 +55,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/alan2207"><img src="https://avatars.githubusercontent.com/u/12713315?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alan Alickovic</b></sub></a><br /><a href="https://github.com/gatsby-uc/plugins/commits?author=alan2207" title="Documentation">📖</a> <a href="#plugin-alan2207" title="Plugin/utility libraries">🔌</a></td>
+    <td align="center"><a href="https://github.com/mattcompiles"><img src="https://avatars.githubusercontent.com/u/8802980?v=4?s=100" width="100px;" alt=""/><br /><sub><b>mattcompiles</b></sub></a><br /><a href="https://github.com/gatsby-uc/plugins/commits?author=mattcompiles" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/packages/gatsby-plugin-vanilla-extract/README.md
+++ b/packages/gatsby-plugin-vanilla-extract/README.md
@@ -5,7 +5,7 @@ Gatsby plugin which wraps the [vanilla-extract](https://vanilla-extract.style/) 
 ## Setup
 
 ```shell
-npm install gatsby-plugin-vanilla-extract @vanilla-extract/babel-plugin @vanilla-extract/css @vanilla-extract/webpack-plugin
+npm install --save-dev gatsby-plugin-vanilla-extract @vanilla-extract/css @vanilla-extract/webpack-plugin
 ```
 
 Add to your site's `gatsby-config.js`.

--- a/packages/gatsby-plugin-vanilla-extract/gatsby-node.js
+++ b/packages/gatsby-plugin-vanilla-extract/gatsby-node.js
@@ -1,11 +1,5 @@
 const { VanillaExtractPlugin } = require("@vanilla-extract/webpack-plugin");
 
-exports.onCreateBabelConfig = ({ actions }, pluginOptions) => {
-  actions.setBabelPlugin({
-    name: require.resolve(`@vanilla-extract/babel-plugin`),
-  });
-};
-
 exports.onCreateWebpackConfig = ({ actions }, pluginOptions) => {
   actions.setWebpackConfig({
     plugins: [new VanillaExtractPlugin(pluginOptions)],

--- a/packages/gatsby-plugin-vanilla-extract/package.json
+++ b/packages/gatsby-plugin-vanilla-extract/package.json
@@ -19,9 +19,8 @@
   },
   "homepage": "https://github.com/gatsby-uc/plugins/tree/main/packages/gatsby-plugin-vanilla-extract#readme",
   "peerDependencies": {
-    "@vanilla-extract/babel-plugin": "^1.0.0",
     "@vanilla-extract/css": "^1.0.0",
-    "@vanilla-extract/webpack-plugin": "^2.0.0",
+    "@vanilla-extract/webpack-plugin": "^2.2.0",
     "gatsby": "^3.0.0 || ^4.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11220,9 +11220,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "gatsby-plugin-vanilla-extract@workspace:packages/gatsby-plugin-vanilla-extract"
   peerDependencies:
-    "@vanilla-extract/babel-plugin": ^1.0.0
     "@vanilla-extract/css": ^1.0.0
-    "@vanilla-extract/webpack-plugin": ^2.0.0
+    "@vanilla-extract/webpack-plugin": ^2.2.0
     gatsby: ^3.0.0 || ^4.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--
  Have any questions? Hopefully we'll have docs soon, in the mean time
  ask in this Pull Request and a maintainer will be happy to help :)
-->

## Description

vanilla-extract no longer needs a babel-plugin so it has been removed and the peer dep on the webpack-plugin has been lifted meaning this is a breaking change. 

### Documentation

See the [`@vanilla-extract/webpack-plugin` changeset](https://github.com/seek-oss/vanilla-extract/blob/master/packages/webpack-plugin/CHANGELOG.md#220) for details. 
<!--
  Where is this documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->
