### PR TITLE
fix(gatsby-plugin-fastify): query params throwing 500

### DIFF
--- a/.changeset/friendly-onions-pretend.md
+++ b/.changeset/friendly-onions-pretend.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": patch
+---
+
+fix(gatsby-plugin-fastify): Fix https://github.com/gatsby-uc/plugins/issues/257 where passing query paSR routes was causing 500.

--- a/packages/gatsby-plugin-fastify/src/__tests__/plugins/serverRoutes.js
+++ b/packages/gatsby-plugin-fastify/src/__tests__/plugins/serverRoutes.js
@@ -201,4 +201,13 @@ describe(`Test Gatsby DSG/SSR Routes`, () => {
 
     expect(response.statusCode).toEqual(403);
   });
+
+  it(`Should return route correctly when queryparams exist`, async () => {
+    const reqponse = await globalFastify.inject({
+      url: "/ssr?test=test",
+      method: "GET",
+    });
+
+    expect(reqponse.statusCode).toEqual(200);
+  });
 });

--- a/packages/gatsby-plugin-fastify/src/utils/routes.ts
+++ b/packages/gatsby-plugin-fastify/src/utils/routes.ts
@@ -8,3 +8,7 @@ export function formatMatchPath(matchPath?: string): string | null {
   }
   return matchPath.replace(/\/\*$/, "*");
 }
+
+export function removeQueryParmsFromUrl(url: string) {
+  return url.split("?", 2)[0];
+}


### PR DESCRIPTION
<!--
  Have any questions? Hopefully we'll have docs soon, in the mean time
  ask in this Pull Request and a maintainer will be happy to help :)
-->

## Description

`req.url` in fastify  contains queryparams...it's not just the path. This was being passed to Gatsby which only expected a path and was throwing an error. Added function to split the URL @ `?` and return the path for use in Gatsby functions.

### Documentation

test added to keep this from reverting.

## Related Issues

 fixes #257
