### PR TITLE
fix(gatsby-plugin-fastify): splat and wildcard routes in redirects

### DIFF
--- a/.changeset/empty-impalas-explode.md
+++ b/.changeset/empty-impalas-explode.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": patch
+---
+
+Fix: Correctly handle splat and wildcard routes for redirects as discussed in #271

--- a/integration-tests/plugin-fastify/gatsby-node.ts
+++ b/integration-tests/plugin-fastify/gatsby-node.ts
@@ -87,6 +87,43 @@ export const createPages: GatsbyNode["createPages"] = async (gatsbyUtilities) =>
     toPath: "http://example.com/*",
     statusCode: 200,
   });
+
+  createRedirect({
+    fromPath: "/redirect/:letter",
+    toPath: "/app/:letter",
+  });
+  createRedirect({
+    fromPath: "/redirect-query?letter=:letter",
+    toPath: "/app/:letter",
+  });
+  createRedirect({
+    fromPath: "/redirect-query-query?letter=:letter",
+    toPath: "/app?letter=:letter",
+  });
+  createRedirect({
+    fromPath: "/redirect-all/*",
+    toPath: "/app/*",
+  });
+  createRedirect({
+    fromPath: "/redirect-all2/*",
+    toPath: "/app/",
+  });
+  createRedirect({
+    fromPath: "/redirect-weird/:path/*",
+    toPath: "/app/:path/*",
+  });
+  createRedirect({
+    fromPath: "/redirect-query-specific?id=1",
+    toPath: "file1.pdf",
+  });
+  createRedirect({
+    fromPath: "/redirect-query-specific?id=2",
+    toPath: "/file2.pdf",
+  });
+  createRedirect({
+    fromPath: "/redirect-query-specific?id=2&letter=:letter",
+    toPath: "/app/:letter/file2.pdf",
+  });
 };
 
 export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({

--- a/packages/gatsby-plugin-fastify/README.md
+++ b/packages/gatsby-plugin-fastify/README.md
@@ -157,6 +157,62 @@ createRedirect({
 
 > The Gatsby docs note ending the to and from paths with `*`. This is not allowed in this plugin. If included they are stripped for compatibility.
 
+### Gatsby Redirects
+
+Our implementation supports several examples as shown by [Gatsby Docs](https://www.gatsbyjs.com/docs/how-to/cloud/working-with-redirects-and-rewrites/).
+
+Basic, splat, wildcard, and Querystring splat redirects should all work. e.g. :
+
+```js
+createRedirect({
+  fromPath: "/perm-redirect",
+  toPath: "/posts/page-1",
+});
+createRedirect({
+  fromPath: "/redirect/:letter", // `/redirect/a`
+  toPath: "/app/:letter", // `/app/a`
+});
+createRedirect({
+  fromPath: "/redirect-query?example=:example", // `/redirect-query?example=test`
+  toPath: "/app/:example", // `/app/test`
+});
+createRedirect({
+  fromPath: "/redirect-query-query?example=:example", // `/redirect-query-query?example=test`
+  fromPath: "/redirect-query-query?example=:example", // `/app?example=test`
+  toPath: "/app?example=:example",
+});
+createRedirect({
+  fromPath: "/redirect-all/*", // `/redirect-all/example`
+  toPath: "/app/*", // `/app/example`
+});
+createRedirect({
+  fromPath: "/redirect-all2/*", // `/redirect-all2/abc/124` | `/redirect-all2/abc/152`
+  toPath: "/app/", // `/app/`
+});
+```
+
+Due to router diferences we have to handle non-splat style query string redirects specially. But they cannot be combined with splat or wildcard routes e.g.
+
+```js
+// This works
+createRedirect({
+  fromPath: "/redirect-query-specific?id=2",
+  toPath: "/file.pdf",
+});
+
+// These worn't work
+createRedirect({
+  fromPath: "/redirect-query-specific?id=2&example=:example",
+  toPath: "/:example/file.pdf",
+});
+createRedirect({
+  fromPath: "/redirect-query-specific/*?id=2",
+  toPath: "/*file.pdf",
+});
+```
+
+> **Note:** While These combos don't currently work it's not imposible to implement such a feature. If you need this feature please consider contributing.
+
 ### Gatsby Functions
 
 Gatsby's [function docs](https://www.gatsbyjs.com/docs/reference/functions/getting-started/) suggest that the `Request` and `Response` objects for your Gatsby functions will be _Express like_ and provide the types from the Gatsby core for these.

--- a/packages/gatsby-plugin-fastify/src/__tests__/plugins/redirects.js
+++ b/packages/gatsby-plugin-fastify/src/__tests__/plugins/redirects.js
@@ -1,3 +1,5 @@
+import { StatusCodes } from "http-status-codes";
+
 describe(`Gatsby Redirects`, () => {
   it(`Should handle permanent redirect`, async () => {
     const response = await fastify.inject({
@@ -5,7 +7,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(301);
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_PERMANENTLY);
     expect(response.headers.location).toEqual("/posts/page-1");
   });
 
@@ -15,7 +17,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(302);
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
     expect(response.headers.location).toEqual("/posts/page-2");
   });
 
@@ -25,7 +27,77 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(307);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/posts/page-3");
+  });
+
+  it(`Should handle redirect with path params`, async () => {
+    const response = await fastify.inject({
+      url: "/redirect/a",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("/app/a");
+  });
+
+  it(`Should handle redirect with query string to params`, async () => {
+    const response = await fastify.inject({
+      url: "/redirect-query?letter=a",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("/app/a");
+  });
+
+  it(`Should handle redirect with query string to other query params`, async () => {
+    const response = await fastify.inject({
+      url: "/redirect-query-query?letter=a",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("/app?letter=a");
+  });
+
+  it(`Should handle redirect with catch all`, async () => {
+    const response = await fastify.inject({
+      url: "/redirect-all/a",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("/app/a");
+  });
+
+  it(`Should handle redirect with catch all to 1 location`, async () => {
+    const response = await fastify.inject({
+      url: "/redirect-all2/a",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("/app/");
+  });
+
+  it(`Should handle redirect correctly with params and catch all`, async () => {
+    const response = await fastify.inject({
+      url: "/redirect-weird/test/more-stuff",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("/app/test/more-stuff");
+  });
+
+  it(`Should handle redirect correctly with specific query strings`, async () => {
+    const response = await fastify.inject({
+      url: "/redirect-query-specific?id=2",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("/file2.pdf");
   });
 });

--- a/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
@@ -1,9 +1,11 @@
 import { StatusCodes } from "http-status-codes";
 
+import { removeQueryParmsFromUrl, buildUrlFromParams } from "../utils/routes";
+
 import type { FastifyPluginAsync } from "fastify";
 import type { IRedirect } from "gatsby/dist/redux/types";
 
-export function getResponseCode(redirect: IRedirect): StatusCodes {
+function getResponseCode(redirect: IRedirect): StatusCodes {
   return (
     redirect.statusCode ||
     (redirect.isPermanent ? StatusCodes.MOVED_PERMANENTLY : StatusCodes.MOVED_TEMPORARILY)
@@ -15,16 +17,52 @@ export const handleRedirects: FastifyPluginAsync<{
 }> = async (fastify, { redirects }) => {
   fastify.log.info(`Registering ${redirects.length} redirect(s)`);
 
-  for (const redirect of redirects) {
-    const responseCode = getResponseCode(redirect);
+  const queryStringHandlers: {
+    [s: string]: IRedirect;
+  } = {};
+
+  const alreadyRegisterd = new Set();
+
+  for (let redirect of redirects) {
+    let responseCode = getResponseCode(redirect);
     fastify.log.debug(
       `Registering "${redirect.fromPath}" as redirect to "${redirect.toPath}" with HTTP status code "${responseCode}".`
     );
 
-    fastify.get(redirect.fromPath, (_req, reply) => {
-      reply.appendModuleHeader("Redirects");
+    /* Fastify can't register routes currently with the query stirngs in the path.
+     *  We must strip these out and only register the path once.
+     *  We can then check, in that single route, whether the entire url(including the query params) matches a redirect path, if it does
+     *
+     */
+    const cleanFromPath = removeQueryParmsFromUrl(redirect.fromPath);
+    const isCleanedPath = cleanFromPath != redirect.fromPath;
 
-      reply.code(responseCode).redirect(redirect.toPath);
-    });
+    if (isCleanedPath) {
+      queryStringHandlers[redirect.fromPath] = redirect;
+    }
+
+    if (!alreadyRegisterd.has(cleanFromPath)) {
+      isCleanedPath && alreadyRegisterd.add(cleanFromPath);
+
+      fastify.get<{
+        Params: {
+          [s: string]: any;
+        };
+        Querystring: {
+          [s: string]: any;
+        };
+      }>(cleanFromPath, { config: {} }, (req, reply) => {
+        reply.appendModuleHeader("Redirects");
+
+        if (isCleanedPath && queryStringHandlers[req.url]) {
+          redirect = queryStringHandlers[req.url];
+          responseCode = getResponseCode(redirect);
+        }
+
+        const toUrl = buildUrlFromParams(redirect.toPath, { ...req.params, ...req.query });
+
+        reply.code(responseCode).redirect(toUrl);
+      });
+    }
   }
 };

--- a/packages/gatsby-plugin-fastify/src/utils/routes.ts
+++ b/packages/gatsby-plugin-fastify/src/utils/routes.ts
@@ -9,3 +9,16 @@ export function formatMatchPath(matchPath: string): string {
 export function removeQueryParmsFromUrl(url: string) {
   return url.split("?", 2)[0];
 }
+
+export function buildUrlFromParams(path: string, data: { [s: string]: string } = {}) {
+  return path.replace(/:(\w+)|(\*)/gi, function (_match, p1, p2) {
+    let lookupString = p1 ?? p2;
+    let replacement = data[lookupString];
+
+    if (!replacement) {
+      throw new Error("Could not find url parameter " + lookupString + " in passed data object");
+    }
+
+    return replacement;
+  });
+}


### PR DESCRIPTION
<!--
  Have any questions? Hopefully we'll have docs soon, in the mean time
  ask in this Pull Request and a maintainer will be happy to help :)
-->

## Description
correctly passes splat and wildcards for redirect paths. 

### Documentation
done

## Related Issues
closes #271
