### PR TITLE
support colons in redirect `toPath`s

### DIFF
--- a/.changeset/rare-mugs-deny.md
+++ b/.changeset/rare-mugs-deny.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": patch
+---
+
+support colons in redirect `toPath`s

--- a/integration-tests/plugin-fastify/gatsby-node.ts
+++ b/integration-tests/plugin-fastify/gatsby-node.ts
@@ -140,6 +140,10 @@ export const createPages: GatsbyNode["createPages"] = async (gatsbyUtilities) =>
     fromPath: "/Category::URL",
     toPath: "/wiki/Category:URL",
   });
+  createRedirect({
+    fromPath: "/some/:thing/all",
+    toPath: "/something::thing/*",
+  });
 };
 
 export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({

--- a/integration-tests/plugin-fastify/gatsby-node.ts
+++ b/integration-tests/plugin-fastify/gatsby-node.ts
@@ -124,6 +124,22 @@ export const createPages: GatsbyNode["createPages"] = async (gatsbyUtilities) =>
     fromPath: "/redirect-query-specific?id=2&letter=:letter",
     toPath: "/app/:letter/file2.pdf",
   });
+  createRedirect({
+    fromPath: "/wiki/category/url",
+    toPath: "https://en.wikipedia.org/wiki/Category:URL",
+  });
+  createRedirect({
+    fromPath: "/wiki/category/:category",
+    toPath: "https://en.wikipedia.org/wiki/Category::category",
+  });
+  createRedirect({
+    fromPath: "/wiki/:namespace/:value",
+    toPath: "https://en.wikipedia.org/wiki/:namespace::value",
+  });
+  createRedirect({
+    fromPath: "/Category::URL",
+    toPath: "/wiki/Category:URL",
+  });
 };
 
 export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({

--- a/packages/gatsby-plugin-fastify/src/__tests__/plugins/redirects.js
+++ b/packages/gatsby-plugin-fastify/src/__tests__/plugins/redirects.js
@@ -140,4 +140,13 @@ describe(`Gatsby Redirects`, () => {
     expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
     expect(response.headers.location).toEqual("/wiki/Category:URL");
   });
+
+  it(`Should error when including an asterisk in toPath without a wildcard in fromPath, even if there is a splat or colon`, async () => {
+    const response = await fastify.inject({
+      url: "/some/thing/all",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.INTERNAL_SERVER_ERROR);
+  });
 });

--- a/packages/gatsby-plugin-fastify/src/__tests__/plugins/redirects.js
+++ b/packages/gatsby-plugin-fastify/src/__tests__/plugins/redirects.js
@@ -100,4 +100,44 @@ describe(`Gatsby Redirects`, () => {
     expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
     expect(response.headers.location).toEqual("/file2.pdf");
   });
+
+  it(`Should handle colons in toPaths without splat in fromPath`, async () => {
+    const response = await fastify.inject({
+      url: "/wiki/category/url",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("https://en.wikipedia.org/wiki/Category:URL");
+  });
+
+  it(`Should handle splats in fromPaths with colons in toPaths`, async () => {
+    const response = await fastify.inject({
+      url: "/wiki/category/URL",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("https://en.wikipedia.org/wiki/Category:URL");
+  });
+
+  it(`Should handle multiple splats in fromPaths with colons in toPaths`, async () => {
+    const response = await fastify.inject({
+      url: "/wiki/Category/URL",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("https://en.wikipedia.org/wiki/Category:URL");
+  });
+
+  it(`Should handle colons in fromPaths that are not splats via double colon`, async () => {
+    const response = await fastify.inject({
+      url: "/Category:URL",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.headers.location).toEqual("/wiki/Category:URL");
+  });
 });

--- a/packages/gatsby-plugin-fastify/src/utils/routes.ts
+++ b/packages/gatsby-plugin-fastify/src/utils/routes.ts
@@ -11,8 +11,8 @@ export function removeQueryParmsFromUrl(url: string) {
 }
 
 export function buildUrlFromParams(path: string, data: { [s: string]: string } = {}) {
-  return path.replace(/:(\w+)|(\*)/gi, function (_match, p1, p2) {
-    if (p1 && !data[p1]) return _match; // :Something in toPath does not have a splat in fromPath pass it through colon intact
+  return path.replace(/:(\w+)|(\*)/gi, function (match, p1, p2) {
+    if (p1 && !data[p1]) return match; // :Something in toPath does not have a splat in fromPath pass it through colon intact
     let lookupString = p1 ?? p2;
     let replacement = data[lookupString];
 

--- a/packages/gatsby-plugin-fastify/src/utils/routes.ts
+++ b/packages/gatsby-plugin-fastify/src/utils/routes.ts
@@ -12,6 +12,7 @@ export function removeQueryParmsFromUrl(url: string) {
 
 export function buildUrlFromParams(path: string, data: { [s: string]: string } = {}) {
   return path.replace(/:(\w+)|(\*)/gi, function (_match, p1, p2) {
+    if (p1 && !data[p1]) return _match; // :Something in toPath does not have a splat in fromPath pass it through colon intact
     let lookupString = p1 ?? p2;
     let replacement = data[lookupString];
 


### PR DESCRIPTION
<!--
  Have any questions? Hopefully we'll have docs soon, in the mean time
  ask in this Pull Request and a maintainer will be happy to help :)
-->

## Description

if a splat is found in the `toPath` but it doesn't have a matching splat in the `fromPath` pass it through as is (with the colon) as it's more likely a `toPath` with a colon in it than an error in the redirect.

@moonmeister not sure if this is the best solution, but all existing and new tests are passing. 

### Documentation

fixes a bug, existing redirects documentation covers it

## Related Issues

Fixes https://github.com/gatsby-uc/plugins/issues/291
