### PR TITLE
fix(gatsby-plugin-fastify): Update default response codes and handle all HTTP methods for redirects

### DIFF
--- a/.changeset/gorgeous-panthers-relate.md
+++ b/.changeset/gorgeous-panthers-relate.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": minor
+---
+
+We've changed the default redirect codes to 307/308 from 301/302. See the redirects docs for more info. They this woun't break most usecases, if you were expecting a specific response code, it may. You may uses Gatsby's "statusCode" field to explicitly set the satus code back to 301/302.

--- a/.changeset/mean-ghosts-think.md
+++ b/.changeset/mean-ghosts-think.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": patch
+---
+
+feat: Changed redirects to respond on any HTTP medthod, not just GET.

--- a/integration-tests/plugin-fastify/gatsby-node.ts
+++ b/integration-tests/plugin-fastify/gatsby-node.ts
@@ -73,7 +73,7 @@ export const createPages: GatsbyNode["createPages"] = async (gatsbyUtilities) =>
   createRedirect({
     fromPath: "/alt-redirect",
     toPath: "/posts/page-3",
-    statusCode: 307,
+    statusCode: 301,
   });
 
   createRedirect({

--- a/packages/gatsby-plugin-fastify/README.md
+++ b/packages/gatsby-plugin-fastify/README.md
@@ -159,7 +159,11 @@ createRedirect({
 
 ### Gatsby Redirects
 
-Our implementation supports several examples as shown by [Gatsby Docs](https://www.gatsbyjs.com/docs/how-to/cloud/working-with-redirects-and-rewrites/).
+We support the use of `statusCode` but do not currently support `conditions`, `ignoreCase`, or `force` as discussed in the [`createRedirect` docs](https://www.gatsbyjs.com/docs/reference/config-files/actions/#createRedirect).
+
+For various reasons discussed in [this article](https://kinsta.com/knowledgebase/307-redirect/), the `isPermanent` boolean toggles HTTP `307 Temporray Redirect` and `308 Permanent Redirect` instead of `301 Moved Permanently` and `302 Found`. If you need to use `statusCode` onyour redirects to explicitly set the response code.
+
+Our implementation supports dynamic redirects as shown by [Gatsby Cloud Docs](https://www.gatsbyjs.com/docs/how-to/cloud/working-with-redirects-and-rewrites/).
 
 Basic, splat, wildcard, and Querystring splat redirects should all work. e.g. :
 
@@ -211,7 +215,7 @@ createRedirect({
 });
 ```
 
-> **Note:** While These combos don't currently work it's not imposible to implement such a feature. If you need this feature please consider contributing.
+> **Note:** While these combos don't currently work it's not imposible to implement such a feature. If you need this feature please consider contributing.
 
 ### Gatsby Functions
 
@@ -231,4 +235,4 @@ export default function handler(req: FastifyRequest, res: FastifyReply) {
 
 ### Gatsby Routing
 
-We have implemented a compatability layer to support the Gatsby flavor of routing for [Gatsby Functions](https://www.gatsbyjs.com/docs/reference/functions/routing/) and [File System Routing API](https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/#syntax-client-only-routes). This should be transparent and if you follow the Gatsby docs for routing we should now support all those modes. This very well might not beperfect, if you have issues with routing please file a bug with a reproduction.
+We have implemented a compatability layer to support the Gatsby flavor of routing for [Gatsby Functions](https://www.gatsbyjs.com/docs/reference/functions/routing/) and [File System Routing API](https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/#syntax-client-only-routes). This should be transparent and if you follow the Gatsby docs for routing we should now support all those modes. This very well might not be perfect, if you have issues with routing please file a bug with a reproduction.

--- a/packages/gatsby-plugin-fastify/src/__tests__/plugins/redirects.js
+++ b/packages/gatsby-plugin-fastify/src/__tests__/plugins/redirects.js
@@ -7,7 +7,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_PERMANENTLY);
+    expect(response.statusCode).toEqual(StatusCodes.PERMANENT_REDIRECT);
     expect(response.headers.location).toEqual("/posts/page-1");
   });
 
@@ -17,7 +17,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/posts/page-2");
   });
 
@@ -27,7 +27,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
+    expect(response.statusCode).toEqual(StatusCodes.MOVED_PERMANENTLY);
     expect(response.headers.location).toEqual("/posts/page-3");
   });
 
@@ -37,7 +37,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/app/a");
   });
 
@@ -47,7 +47,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/app/a");
   });
 
@@ -57,7 +57,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/app?letter=a");
   });
 
@@ -67,7 +67,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/app/a");
   });
 
@@ -77,7 +77,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/app/");
   });
 
@@ -87,7 +87,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/app/test/more-stuff");
   });
 
@@ -97,7 +97,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/file2.pdf");
   });
 
@@ -107,7 +107,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("https://en.wikipedia.org/wiki/Category:URL");
   });
 
@@ -117,7 +117,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("https://en.wikipedia.org/wiki/Category:URL");
   });
 
@@ -127,7 +127,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("https://en.wikipedia.org/wiki/Category:URL");
   });
 
@@ -137,7 +137,7 @@ describe(`Gatsby Redirects`, () => {
       method: "GET",
     });
 
-    expect(response.statusCode).toEqual(StatusCodes.MOVED_TEMPORARILY);
+    expect(response.statusCode).toEqual(StatusCodes.TEMPORARY_REDIRECT);
     expect(response.headers.location).toEqual("/wiki/Category:URL");
   });
 

--- a/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
@@ -8,7 +8,7 @@ import type { IRedirect } from "gatsby/dist/redux/types";
 function getResponseCode(redirect: IRedirect): StatusCodes {
   return (
     redirect.statusCode ||
-    (redirect.isPermanent ? StatusCodes.MOVED_PERMANENTLY : StatusCodes.MOVED_TEMPORARILY)
+    (redirect.isPermanent ? StatusCodes.PERMANENT_REDIRECT : StatusCodes.TEMPORARY_REDIRECT)
   );
 }
 

--- a/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/redirects.ts
@@ -44,7 +44,7 @@ export const handleRedirects: FastifyPluginAsync<{
     if (!alreadyRegisterd.has(cleanFromPath)) {
       isCleanedPath && alreadyRegisterd.add(cleanFromPath);
 
-      fastify.get<{
+      fastify.all<{
         Params: {
           [s: string]: string;
         };


### PR DESCRIPTION
Makes redirects more flexible to include not just GET method, but all HTTP methods. Also changes default response codes to be 307/308 instead of 301/302. These newer codes are more strict and should be default. `statusCode` field can be used in the Gatsby `createRediirect` to override. 
