### PR TITLE
feat(gatsby-source-strapi): add httpHeaders

### DIFF
--- a/.changeset/shiny-ties-lick.md
+++ b/.changeset/shiny-ties-lick.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": patch
+---
+
+feat(gatsby-source-strapi): add a customized headers options that gatsby could request a remote file which may need authorization.

--- a/packages/gatsby-source-strapi/README.md
+++ b/packages/gatsby-source-strapi/README.md
@@ -77,7 +77,7 @@ const strapiConfig = {
   accessToken: process.env.STRAPI_TOKEN,
   collectionTypes: ["article", "company", "author"],
   singleTypes: [],
-  headersOptions: {
+  remoteFileHeaders: {
     /**
      * Customized request headers
      * For http request with a image or other files need authorization

--- a/packages/gatsby-source-strapi/README.md
+++ b/packages/gatsby-source-strapi/README.md
@@ -77,6 +77,15 @@ const strapiConfig = {
   accessToken: process.env.STRAPI_TOKEN,
   collectionTypes: ["article", "company", "author"],
   singleTypes: [],
+  headersOptions: {
+    /**
+     * Customized request headers
+     * For http request with a image or other files need authorization
+     * For expamle: Fetch a CDN file which has a security config when gatsby building needs
+     */
+    Referer: "https://your-site-domain/",
+    // Authorization: "Bearer eyJhabcdefg_replace_it_with_your_own_token",
+  },
 };
 
 module.exports = {

--- a/packages/gatsby-source-strapi/src/download-media-files.js
+++ b/packages/gatsby-source-strapi/src/download-media-files.js
@@ -56,7 +56,7 @@ export const downloadFile = async (file, context) => {
     store,
     strapiConfig,
   } = context;
-  const { apiURL, headersOptions } = strapiConfig;
+  const { apiURL, remoteFileHeaders } = strapiConfig;
 
   let fileNodeID;
 
@@ -80,7 +80,7 @@ export const downloadFile = async (file, context) => {
         cache,
         createNode,
         createNodeId,
-        httpHeaders: headersOptions || {},
+        httpHeaders: remoteFileHeaders || {},
       });
 
       if (fileNode) {

--- a/packages/gatsby-source-strapi/src/download-media-files.js
+++ b/packages/gatsby-source-strapi/src/download-media-files.js
@@ -56,7 +56,7 @@ export const downloadFile = async (file, context) => {
     store,
     strapiConfig,
   } = context;
-  const { apiURL } = strapiConfig;
+  const { apiURL, headersOptions } = strapiConfig;
 
   let fileNodeID;
 
@@ -80,6 +80,7 @@ export const downloadFile = async (file, context) => {
         cache,
         createNode,
         createNodeId,
+        httpHeaders: headersOptions || {},
       });
 
       if (fileNode) {


### PR DESCRIPTION
Add it to strapiConfig for fetching a remote file

## Description

When we write a blog has a external link as a image, the image also upload by ourself on a cdn server but cannot access directly. We should add some customized http header options to fetch the file. 

### Documentation

For example:

```js
// gatsby-config.js
const strapiConfig = {
  apiURL: process.env.STRAPI_API_URL,
  accessToken: process.env.STRAPI_TOKEN,
  collectionTypes: ["article", "company", "author"],
  singleTypes: [],
  headersOptions: {
    /**
     * Customized request headers
     * For http request with a image or other files need authorization
     * For expamle: Fetch a CDN file which has a security config when gatsby building needs
     */
    Referer: "https://your-site-domain/",
    // Authorization: "Bearer eyJhabcdefg_replace_it_with_your_own_token",
  },
};
```

## Related Issues

Related to #341 

