### PR TITLE
feat(gatsby-source-airtable): Remove whitespaces in filenames

### DIFF
--- a/packages/gatsby-source-airtable/gatsby-node.js
+++ b/packages/gatsby-source-airtable/gatsby-node.js
@@ -301,7 +301,7 @@ const localFileCheck = async (key, row, { createNodeId, createNode, store, cache
         }
         let attachmentNode = createRemoteFileNode({
           url: attachment.url,
-          name: airtableFile.name.replace(/["%*/:<>?\\|]/g, ""),
+          name: airtableFile.name.replace(/[/\\?%*:|"<>]/g, "").replace(/\s/g, "-").toLowerCase(),
           store,
           cache,
           createNode,


### PR DESCRIPTION
I want to enable whitespace removal in publicURLs.

Due to Meta new specifications, I cannot use og:images anymore if there's any whitespace in there.

Let me know if this is acceptable or I'll find a different workaround like downloading the og:images in a prebuild script and passing those in the static folder.

This was proposed in the old repo here: [https://github.com/jbolda/gatsby-source-airtable/pull/485](https://github.com/jbolda/gatsby-source-airtable/pull/485) and I have been asked to post it here.

Thanks for the review!