### PR TITLE
feat(gatsby-source-strapi): Limit parallel requests to api

### DIFF
--- a/.changeset/gatsby-source-strapi-limit-api.md
+++ b/.changeset/gatsby-source-strapi-limit-api.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": patch
+---
+
+feat(gatsby-source-strapi): Limit parallel requests to api.

--- a/packages/gatsby-source-strapi/README.md
+++ b/packages/gatsby-source-strapi/README.md
@@ -369,6 +369,22 @@ Then use the one of the following queries to fetch a localized content type:
 }
 ```
 
+#### Limiting parallel requests
+
+With huge datasets in strapi parallel requests can be limited with the following option.
+
+```javascript
+const strapiConfig = {
+  // ...
+  apiURL: process.env.STRAPI_API_URL,
+  accessToken: process.env.STRAPI_TOKEN,
+  maxParallelRequests: 10,
+  collectionTypes: [
+    // ...
+  ],
+};
+```
+
 ## Gatsby cloud and preview environment setup
 
 ### Setup

--- a/packages/gatsby-source-strapi/src/fetch.js
+++ b/packages/gatsby-source-strapi/src/fetch.js
@@ -164,7 +164,9 @@ export const fetchEntities = async ({ endpoint, queryParams, uid, pluginOptions 
     const chunkSize = maxParallelRequests || fetchPagesPromises.length;
     const results = [];
     for (let index = 0; index < pagesToGet.length; index += chunkSize) {
-      results.push(await Promise.all(fetchPagesPromises.slice(index, index + chunkSize).map((x) => x())));
+      results.push(
+        await Promise.all(fetchPagesPromises.slice(index, index + chunkSize).map((x) => x()))
+      );
     }
 
     const cleanedData = [...data, ...flattenDeep(results)].map((entry) =>


### PR DESCRIPTION
## Description

Adding max parallel limit for entities array list

### Documentation

Added additional strapi config `maxParallelRequests` to plugin config.
Updated README.md

## Related Issues

Implements #372 
