### PR TITLE
Fixes issue where pagination is used while filter is also active

### DIFF
--- a/packages/gatsby-source-strapi/src/gatsby-node.js
+++ b/packages/gatsby-source-strapi/src/gatsby-node.js
@@ -82,12 +82,16 @@ export const sourceNodes = async (
   if (lastFetched) {
     // Add the updatedAt filter
     const deltaEndpoints = endpoints.map((endpoint) => {
+      const lastEndpoint = { ...endpoint };
+      if (lastEndpoint.queryParams.pagination) {
+        lastEndpoint.queryParams.pagination.page = 1;
+      }
       return {
-        ...endpoint,
+        ...lastEndpoint,
         queryParams: {
-          ...endpoint.queryParams,
+          ...lastEndpoint.queryParams,
           filters: {
-            ...endpoint.queryParams.filters,
+            ...lastEndpoint.queryParams.filters,
             updatedAt: { $gt: lastFetched },
           },
         },


### PR DESCRIPTION
## Description

This fixes an issue where using the gatsby cache will not pick up the latest article because of pagination issues.

## Related Issues

Fixes #393

