### PR TITLE
feat(gatsby-source-strapi): Source strapi throttle

### DIFF
--- a/.changeset/late-waves-grin.md
+++ b/.changeset/late-waves-grin.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": patch
+---
+
+add `maxParallelRequests` config option for users to provide, and refactor to use a single axios instance to all functions

--- a/packages/gatsby-source-strapi/README.md
+++ b/packages/gatsby-source-strapi/README.md
@@ -77,6 +77,7 @@ const strapiConfig = {
   accessToken: process.env.STRAPI_TOKEN,
   collectionTypes: ["article", "company", "author"],
   singleTypes: [],
+  maxParallelRequests: 5, // (Optional) Default: Number.POSITIVE_INFINITY
   remoteFileHeaders: {
     /**
      * Customized request headers

--- a/packages/gatsby-source-strapi/src/axios-instance.js
+++ b/packages/gatsby-source-strapi/src/axios-instance.js
@@ -1,18 +1,70 @@
 import axios from "axios";
 
-const createInstance = (config) => {
-  const headers = { ...config?.headers };
+/**
+ * Inspiration from:
+ * https://gist.github.com/matthewsuan/2bdc9e7f459d5b073d58d1ebc0613169
+ *
+ * @param {AxiosInstance} axiosInstance
+ * @param {number} maxParallelRequests
+ */
+const throttlingInterceptors = (axiosInstance, maxParallelRequests) => {
+  const INTERVAL_MS = 400; // Wait time until retrying request
+  let PENDING_REQUESTS = 0;
 
-  if (config.accessToken) {
-    headers.authorization = `Bearer ${config.accessToken}`;
+  /** Axios Request Interceptor */
+  axiosInstance.interceptors.request.use(function (config) {
+    return new Promise((resolve, _) => {
+      let interval = setInterval(() => {
+        if (PENDING_REQUESTS < maxParallelRequests) {
+          PENDING_REQUESTS++;
+          clearInterval(interval);
+          resolve(config);
+        }
+      }, INTERVAL_MS);
+    });
+  });
+
+  /** Axios Response Interceptor */
+  axiosInstance.interceptors.response.use(
+    function (response) {
+      PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1);
+      return Promise.resolve(response);
+    },
+    function (error) {
+      PENDING_REQUESTS = Math.max(0, PENDING_REQUESTS - 1);
+      return Promise.reject(error);
+    }
+  );
+};
+
+/**
+ *
+ * @param {Object} strapiConfig - Strapi configuration object
+ * @param {string} strapiConfig.apiURL - Strapi API endpoint
+ * @param {Object|undefined} strapiConfig.headers - Headers to be sent with each request
+ * @param {number|undefined} strapiConfig.maxParallelRequests - Number of parallel requests
+ * @param {string} strapiConfig.accessToken - Strapi access token
+ * @returns {AxiosInstance}
+ */
+export const createAxiosInstance = (strapiConfig) => {
+  const {
+    maxParallelRequests = Number.POSITIVE_INFINITY,
+    headers = {},
+    accessToken,
+    apiURL,
+  } = strapiConfig;
+
+  if (accessToken) {
+    headers.authorization = `Bearer ${accessToken}`;
   }
 
   const instance = axios.create({
-    baseURL: config.apiURL,
+    baseURL: apiURL,
     headers,
   });
 
+  /** Add throttling interceptors */
+  throttlingInterceptors(instance, maxParallelRequests);
+
   return instance;
 };
-
-export default createInstance;

--- a/packages/gatsby-source-strapi/src/axios-instance.js
+++ b/packages/gatsby-source-strapi/src/axios-instance.js
@@ -8,7 +8,7 @@ import axios from "axios";
  * @param {number} maxParallelRequests
  */
 const throttlingInterceptors = (axiosInstance, maxParallelRequests) => {
-  const INTERVAL_MS = 400; // Wait time until retrying request
+  const INTERVAL_MS = 50; // Wait time until retrying request
   let PENDING_REQUESTS = 0;
 
   /** Axios Request Interceptor */

--- a/packages/gatsby-source-strapi/src/download-media-files.js
+++ b/packages/gatsby-source-strapi/src/download-media-files.js
@@ -2,7 +2,6 @@ import { Parser } from "commonmark";
 import qs from "qs";
 import { createRemoteFileNode } from "gatsby-source-filesystem";
 import { getContentTypeSchema } from "./helpers";
-import createInstance from "./axios-instance";
 
 const reader = new Parser();
 
@@ -103,12 +102,11 @@ export const downloadFile = async (file, context) => {
 /**
  * Extract images and create remote nodes for images in all fields.
  * @param {Object} item the entity
- * @param {Object} ctx gatsby function
+ * @param {Object} context gatsby function
  * @param {String} uid the main schema uid
  */
 const extractImages = async (item, context, uid) => {
-  const { schemas, strapiConfig } = context;
-  const axiosInstance = createInstance(strapiConfig);
+  const { schemas, strapiConfig, axiosInstance } = context;
   const schema = getContentTypeSchema(schemas, uid);
   const { apiURL } = strapiConfig;
 

--- a/packages/gatsby-source-strapi/src/fetch.js
+++ b/packages/gatsby-source-strapi/src/fetch.js
@@ -1,10 +1,8 @@
 import { castArray, flattenDeep } from "lodash";
-import createInstance from "./axios-instance";
 import qs from "qs";
 import { cleanData } from "./clean-data";
 
-export const fetchStrapiContentTypes = async (strapiConfig) => {
-  const axiosInstance = createInstance(strapiConfig);
+export const fetchStrapiContentTypes = async (axiosInstance) => {
   const [
     {
       data: { data: contentTypes },
@@ -25,8 +23,7 @@ export const fetchStrapiContentTypes = async (strapiConfig) => {
 };
 
 export const fetchEntity = async ({ endpoint, queryParams, uid, pluginOptions }, context) => {
-  const { strapiConfig, reporter } = context;
-  const axiosInstance = createInstance(strapiConfig);
+  const { reporter, axiosInstance } = context;
 
   const options = {
     method: "GET",
@@ -100,8 +97,7 @@ export const fetchEntity = async ({ endpoint, queryParams, uid, pluginOptions },
 };
 
 export const fetchEntities = async ({ endpoint, queryParams, uid, pluginOptions }, context) => {
-  const { strapiConfig, reporter } = context;
-  const axiosInstance = createInstance(strapiConfig);
+  const { reporter, axiosInstance } = context;
 
   const options = {
     method: "GET",

--- a/packages/gatsby-source-strapi/src/gatsby-node.js
+++ b/packages/gatsby-source-strapi/src/gatsby-node.js
@@ -7,6 +7,7 @@ import {
   makeParentNodeName,
 } from "./helpers";
 import { createNodes } from "./normalize";
+import { createAxiosInstance } from "./axios-instance";
 
 const LAST_FETCHED_KEY = "timestamp";
 
@@ -34,12 +35,15 @@ export const sourceNodes = async (
     strapiConfig.collectionTypes = [];
   }
 
-  const { schemas } = await fetchStrapiContentTypes(strapiConfig);
+  const axiosInstance = createAxiosInstance(strapiConfig);
+
+  const { schemas } = await fetchStrapiContentTypes(axiosInstance);
 
   const { deleteNode, touchNode } = actions;
 
   const context = {
     strapiConfig,
+    axiosInstance,
     actions,
     schemas,
     createContentDigest,


### PR DESCRIPTION
## Description

Continues the work of this PR: https://github.com/gatsby-uc/plugins/pull/373#issuecomment-1454858001

With a slightly different approach, as I now construct and use only one Axios instance, to make the interceptors work properly.

Tested with Strapi v4, Gatsby v5 (`5.6.0`) and seems to work as expected

### Documentation

Updated the readme on how to use the `maxParallelRequests` inside the configuration.

## Related Issues

Related to #373 
Fixes #372 
