### PR TITLE
fix(gatsby-source-strapi) refetching data pagination fix

### DIFF
--- a/.changeset/kind-fireants-search.md
+++ b/.changeset/kind-fireants-search.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": patch
+---
+
+fix(gatsby-source-strapi) make sure the pagination is not mutated when refetching

--- a/.changeset/warm-cooks-rush.md
+++ b/.changeset/warm-cooks-rush.md
@@ -3,4 +3,4 @@
 ---
 
 fix(packages): update dependency axios to v1
-Thanks to @konsalex for some manual testing. Due to the lack of automated tests we cannot guarantee this update won't break anything, please report any issues you may run into.  
+Thanks to @konsalex for some manual testing. Due to the lack of automated tests we cannot guarantee this update won't break anything, please report any issues you may run into.

--- a/packages/gatsby-source-strapi/src/fetch.js
+++ b/packages/gatsby-source-strapi/src/fetch.js
@@ -118,7 +118,9 @@ export const fetchEntities = async ({ endpoint, queryParams, uid, pluginOptions 
 
   try {
     reporter.info(
-      `Starting to fetch data from Strapi - ${options.url} with ${JSON.stringify(options.params)}`
+      `Starting to fetch data from Strapi - ${options.url} with ${JSON.stringify(
+        options.paramsSerializer(options.params)
+      )}`
     );
 
     const { data: response } = await axiosInstance(options);
@@ -137,13 +139,18 @@ export const fetchEntities = async ({ endpoint, queryParams, uid, pluginOptions 
       return (async () => {
         const fetchOptions = {
           ...options,
+          params: {
+            ...options.params,
+            pagination: {
+              ...options.params.pagination,
+              page,
+            },
+          },
         };
 
-        fetchOptions.params.pagination.page = page;
-
         reporter.info(
-          `Starting to fetch data from Strapi - ${fetchOptions.url} with ${JSON.stringify(
-            options.paramsSerializer(options.params)
+          `Starting to fetch page ${page} from Strapi - ${fetchOptions.url} with ${JSON.stringify(
+            options.paramsSerializer(fetchOptions.params)
           )}`
         );
 


### PR DESCRIPTION
## Description

currently, the params object was being mutated, resulting in the original query options to contain the latest fetched page (e.g. 4), which made refetches query the 4th page, not back from page 1.

Also changed the logging output to use the paramsSerializer

## Related Issues

Fixes #393

Addresses #394
