### PR TITLE
bug(gatsby-plugin-fastify): all reverse proxy redirects end up as wildcards

### DIFF
--- a/.changeset/stale-snails-sip.md
+++ b/.changeset/stale-snails-sip.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": patch
+---
+
+switch to using `@fastify/reply-from` to ensure non-wildcard redirects only respond at the specified routes

--- a/packages/gatsby-plugin-fastify/package.json
+++ b/packages/gatsby-plugin-fastify/package.json
@@ -33,6 +33,7 @@
     "@fastify/accepts": "^4.1.0",
     "@fastify/http-proxy": "^8.4.0",
     "@fastify/middie": "^8.1.0",
+    "@fastify/reply-from": "^9.0.1",
     "@fastify/static": "^6.9.0",
     "fastify-plugin": "^4.5.0",
     "fs-extra": "^11.1.0",

--- a/packages/gatsby-plugin-fastify/src/__tests__/plugins/reverse-proxy.js
+++ b/packages/gatsby-plugin-fastify/src/__tests__/plugins/reverse-proxy.js
@@ -1,34 +1,74 @@
+import { FG_MODULE_HEADER } from "../../utils/headers";
+
 describe(`Test Gatsby Reverse Proxy Routes`, () => {
-  it(`Should serve Reverse Proxy route`, async () => {
+  it(`Should serve specific Reverse Proxy route with or without trailing slash`, async () => {
     const response = await fastify.inject({
       url: "/example-proxy/",
       method: "GET",
     });
-
-    expect(response.statusCode).toEqual(200);
-    expect(response.headers["content-type"]).toContain("text/html");
-    expect(response.headers["x-gatsby-fastify"]).toContain("Reverse Proxy");
-    expect(response.payload).toContain("Example Domain");
-  });
-
-  it(`Should serve Reverse Proxy route made with trailing *`, async () => {
-    const response = await fastify.inject({
-      url: "/example-proxy-star/",
+    const response2 = await fastify.inject({
+      url: "/example-proxy",
       method: "GET",
     });
-
     expect(response.statusCode).toEqual(200);
     expect(response.headers["content-type"]).toContain("text/html");
-    expect(response.headers["x-gatsby-fastify"]).toContain("Reverse Proxy");
+    expect(response.headers[FG_MODULE_HEADER]).toContain("Reverse Proxy");
     expect(response.payload).toContain("Example Domain");
+    expect(response2.statusCode).toEqual(200);
+    expect(response2.headers["content-type"]).toContain("text/html");
+    expect(response2.headers[FG_MODULE_HEADER]).toContain("Reverse Proxy");
+    expect(response2.payload).toContain("Example Domain");
   });
 
-  it(`Should not serve Reverse Proxy route made with trailing * at *`, async () => {
+  it(`Should serve specific Reverse Proxy only at the specified route`, async () => {
     const response = await fastify.inject({
-      url: "/example-proxy-star/*",
+      url: "/example-proxy-anything-else",
+      method: "GET",
+    });
+    const response2 = await fastify.inject({
+      url: "/example-proxy/anything-else",
       method: "GET",
     });
 
     expect(response.statusCode).toEqual(404);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.headers[FG_MODULE_HEADER]).toContain("404");
+    expect(response.payload).toContain("Gatsby Plugin Fastify");
+    expect(response2.statusCode).toEqual(404);
+    expect(response2.headers["content-type"]).toContain("text/html");
+    expect(response2.headers[FG_MODULE_HEADER]).toContain("404");
+    expect(response2.payload).toContain("Gatsby Plugin Fastify");
+  });
+
+  it(`Should serve Reverse Proxy route made with trailing * with or without trailing slash`, async () => {
+    const response = await fastify.inject({
+      url: "/example-proxy-star/",
+      method: "GET",
+    });
+    const response2 = await fastify.inject({
+      url: "/example-proxy-star",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.headers[FG_MODULE_HEADER]).toContain("Reverse Proxy");
+    expect(response.payload).toContain("Example Domain");
+    expect(response2.statusCode).toEqual(200);
+    expect(response2.headers["content-type"]).toContain("text/html");
+    expect(response2.headers[FG_MODULE_HEADER]).toContain("Reverse Proxy");
+    expect(response2.payload).toContain("Example Domain");
+  });
+
+  it(`Should serve wildcard Reverse Proxy routes via proxied server`, async () => {
+    const response = await fastify.inject({
+      url: "/example-proxy-star/anything-else",
+      method: "GET",
+    });
+
+    expect(response.statusCode).toEqual(404);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.headers[FG_MODULE_HEADER]).toContain("Reverse Proxy");
+    expect(response.payload).toContain("Example Domain");
   });
 });

--- a/packages/gatsby-plugin-fastify/src/gatsby/proxies-and-redirects.ts
+++ b/packages/gatsby-plugin-fastify/src/gatsby/proxies-and-redirects.ts
@@ -11,8 +11,8 @@ export function getProxiesAndRedirects(store: Store) {
   for (const current of proxiesAndRedirects) {
     if (current.statusCode == 200) {
       results.proxies.push({
-        toPath: current.toPath.replace(/\*$/, ""),
-        fromPath: current.fromPath.replace(/\*$/, ""),
+        toPath: current.toPath,
+        fromPath: current.fromPath,
       });
     } else {
       results.redirects.push(current);

--- a/packages/gatsby-plugin-fastify/src/plugins/reverse-proxy.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/reverse-proxy.ts
@@ -27,8 +27,6 @@ export const handleReverseProxy: FastifyPluginAsync<{
           replyOptions: {
             onResponse: (_request, reply, response) => {
               (reply as FastifyReply).appendModuleHeader("Reverse Proxy");
-              reply.mode = "PROXY";
-              reply.path = proxy.fromPath;
               reply.send(response);
             },
           },
@@ -39,8 +37,6 @@ export const handleReverseProxy: FastifyPluginAsync<{
         });
         fastify.get(cleanFrom, (_request, reply) => {
           (reply as FastifyReply).appendModuleHeader("Reverse Proxy");
-          reply.mode = "PROXY";
-          reply.path = proxy.fromPath;
           reply.from(cleanTo);
         });
       }


### PR DESCRIPTION
<!--
  Have any questions? Hopefully we'll have docs soon, in the mean time
  ask in this Pull Request and a maintainer will be happy to help :)
-->

## Description

use @fastify/reply-from to serve non-wildcard reverse proxy redirects to ensure redirects registered without an asterisk only respond with the proxied server when calling the specifically configured route

## Related Issues

fixes #400