### PR TITLE
Update fetch.js

### DIFF
--- a/packages/gatsby-source-strapi/src/fetch.js
+++ b/packages/gatsby-source-strapi/src/fetch.js
@@ -37,7 +37,9 @@ export const fetchEntity = async ({ endpoint, queryParams, uid, pluginOptions },
 
   try {
     reporter.info(
-      `Starting to fetch data from Strapi - ${options.url} with ${JSON.stringify(options)}`
+      `Starting to fetch data from Strapi - ${options.url} with ${JSON.stringify(
+        options.paramsSerializer(options.params)
+      )}`
     );
 
     // Handle internationalization


### PR DESCRIPTION
add paramsSerializer to singleType reporter info. The latest release add this to collectionTypes, now we still have 2 ways of logging.