### PR TITLE
fix(gatsby-source-strapi): catch logging in fetchEntity

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -328,6 +328,15 @@
       "contributions": [
         "maintenance"
       ]
+    },
+    {
+      "login": "xSyki",
+      "name": "Syki",
+      "avatar_url": "https://avatars.githubusercontent.com/u/86367246?v=4",
+      "profile": "https://github.com/xSyki",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.changeset/chilled-emus-deny.md
+++ b/.changeset/chilled-emus-deny.md
@@ -2,4 +2,4 @@
 "gatsby-source-strapi": patch
 ---
 
-Fix catch logging in fetchEntity
+singleTypes return a 404 when it isn't updated since the latest fetch. Therefor, errors would be silenced. Fix this to report errors that are not 404

--- a/.changeset/chilled-emus-deny.md
+++ b/.changeset/chilled-emus-deny.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": patch
+---
+
+Fix catch logging in fetchEntity

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 <p align="center">
   <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-31-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-32-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 </p>
 
@@ -85,6 +85,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mabhub"><img src="https://avatars.githubusercontent.com/u/1846633?v=4?s=100" width="100px;" alt="mab"/><br /><sub><b>mab</b></sub></a><br /><a href="https://github.com/gatsby-uc/plugins/commits?author=mabhub" title="Code">💻</a> <a href="https://github.com/gatsby-uc/plugins/commits?author=mabhub" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ryan-talus"><img src="https://avatars.githubusercontent.com/u/61983809?v=4?s=100" width="100px;" alt="Ryan Zimmerman"/><br /><sub><b>Ryan Zimmerman</b></sub></a><br /><a href="https://github.com/gatsby-uc/plugins/commits?author=ryan-talus" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/h93xV2"><img src="https://avatars.githubusercontent.com/u/17226133?v=4?s=100" width="100px;" alt="h93xV2"/><br /><sub><b>h93xV2</b></sub></a><br /><a href="#maintenance-h93xV2" title="Maintenance">🚧</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/xSyki"><img src="https://avatars.githubusercontent.com/u/86367246?v=4?s=100" width="100px;" alt="Syki"/><br /><sub><b>Syki</b></sub></a><br /><a href="https://github.com/gatsby-uc/plugins/commits?author=xSyki" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/packages/gatsby-source-strapi/src/fetch.js
+++ b/packages/gatsby-source-strapi/src/fetch.js
@@ -92,11 +92,13 @@ export const fetchEntity = async ({ endpoint, queryParams, uid, pluginOptions },
     return castArray([data.data, ...otherLocalizationsData]).map((entry) =>
       cleanData(entry, { ...context, contentTypeUid: uid })
     );
-  } catch {
-    // reporter.panic(
-    //   `Failed to fetch data from Strapi ${opts.url} with ${JSON.stringify(opts)}`,
-    //   error,
-    // );
+  } catch (error) {
+    if (error.response.status !== 404) {
+      reporter.panic(
+        `Failed to fetch data from Strapi ${options.url} with ${JSON.stringify(options)}`,
+        error
+      );
+    }
     return [];
   }
 };


### PR DESCRIPTION
## Description

Improved logging in fetchEntity catch. We do not log 404 because strapi returns this status if there are no changes since the last download.

## Related Issues

According to https://github.com/gatsby-uc/plugins/issues/410
