### PR TITLE
fix(packages): homepage links in package.json

### DIFF
--- a/.changeset/metal-experts-glow.md
+++ b/.changeset/metal-experts-glow.md
@@ -1,0 +1,14 @@
+---
+"gatsby-plugin-ackee-tracker": minor
+"gatsby-plugin-github-ribbon": minor
+"gatsby-plugin-relative-ci": minor
+"gatsby-plugin-pinterest": minor
+"gatsby-source-packagist": minor
+"gatsby-source-airtable": minor
+"gatsby-source-appwrite": minor
+"gatsby-plugin-fastify": minor
+"gatsby-source-strapi": minor
+"gatsby-source-s3": minor
+---
+
+Fix homepage link for plugins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ To make sure folks can find things please setup the fields correctly when the pl
   "bugs": {
     "url": "https://github.com/gatsby-uc/plugins/issues"
   },
-  "homepage": "https://github.com/gatsby-uc/plugins/packages/gatsby-plugin-name#readme"
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-plugin-name/README.md",
 }
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ To make sure folks can find things please setup the fields correctly when the pl
   "bugs": {
     "url": "https://github.com/gatsby-uc/plugins/issues"
   },
-  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-plugin-name/README.md",
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-plugin-name/README.md"
 }
 ```
 

--- a/packages/gatsby-plugin-ackee-tracker/package.json
+++ b/packages/gatsby-plugin-ackee-tracker/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/gatsby-uc/plugins/issues"
   },
-  "homepage": "https://github.com/gatsby-uc/plugins/packages/gatsby-plugin-ackee-tracker#readme",
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-plugin-ackee-tracker/README.md",
   "license": "MIT",
   "contributors": [
     "Christopher Burns <christopher@tapstudio.co.uk>",

--- a/packages/gatsby-plugin-fastify/package.json
+++ b/packages/gatsby-plugin-fastify/package.json
@@ -2,6 +2,7 @@
   "name": "gatsby-plugin-fastify",
   "description": "Gatsby plugin for integration serving gatsby on Node.js using Fastify.",
   "version": "0.12.4",
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-plugin-fastify/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsby-uc/plugins.git",

--- a/packages/gatsby-plugin-github-ribbon/package.json
+++ b/packages/gatsby-plugin-github-ribbon/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/gatsby-uc/plugins/issues"
   },
-  "homepage": "https://github.com/gatsby-uc/plugins/packages/gatsby-plugin-github-ribbon#readme",
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-plugin-github-ribbon/README.md",
   "scripts": {
     "build": "babel src --out-dir ./dist --ignore \"**/__tests__\"",
     "test": "jest",

--- a/packages/gatsby-plugin-pinterest/package.json
+++ b/packages/gatsby-plugin-pinterest/package.json
@@ -19,6 +19,7 @@
     "url": "https://github.com/gatsby-uc/plugins.git",
     "directory": "packages/gatsby-plugin-pinterest"
   },
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-plugin-pinterest/README.md",
   "scripts": {
     "build": "babel src --out-dir ./dist --ignore \"**/__tests__,**/*.d.ts\" --extensions \".ts,.js\"",
     "test": "jest --coverage"

--- a/packages/gatsby-plugin-relative-ci/package.json
+++ b/packages/gatsby-plugin-relative-ci/package.json
@@ -35,5 +35,5 @@
   "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-plugin-relative-ci/README.md",
   "bugs": {
     "url": "https://github.com/gatsby-uc/plugins/issues"
-  },
+  }
 }

--- a/packages/gatsby-plugin-relative-ci/package.json
+++ b/packages/gatsby-plugin-relative-ci/package.json
@@ -32,8 +32,8 @@
     "url": "https://github.com/gatsby-uc/plugins.git",
     "directory": "packages/gatsby-plugin-relative-ci"
   },
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-plugin-relative-ci/README.md",
   "bugs": {
     "url": "https://github.com/gatsby-uc/plugins/issues"
   },
-  "homepage": "https://github.com/gatsby-uc/plugins/packages/gatsby-plugin-relative-ci#readme"
 }

--- a/packages/gatsby-source-airtable/package.json
+++ b/packages/gatsby-source-airtable/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/gatsby-uc/plugins.git",
     "directory": "packages/gatsby-plugin-airtable"
   },
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-source-airtable/README.md",
   "author": "Jacob Bolda <me@jacobbolda.com>",
   "license": "MIT",
   "main": "index.js",

--- a/packages/gatsby-source-appwrite/package.json
+++ b/packages/gatsby-source-appwrite/package.json
@@ -7,6 +7,7 @@
     "gatsby-plugin",
     "appwrite"
   ],
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-source-appwrite/README.md",
   "contributors": [
     "Alex Patterson <alex@codingcat.dev>"
   ],

--- a/packages/gatsby-source-packagist/package.json
+++ b/packages/gatsby-source-packagist/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/gatsby-uc/plugins/issues"
   },
-  "homepage": "https://github.com/gatsby-uc/plugins/packages/gatsby-source-packagist#readme",
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-source-packagist/README.md",
   "author": "Alex Moon <alex.jared.moon@gmail.com>",
   "license": "MIT",
   "dependencies": {

--- a/packages/gatsby-source-s3/package.json
+++ b/packages/gatsby-source-s3/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/gatsby-uc/plugins.git",
     "directory": "packages/gatsby-source-s3"
   },
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-source-s3/README.md",
   "license": "MIT",
   "keywords": [
     "gatsby",

--- a/packages/gatsby-source-strapi/package.json
+++ b/packages/gatsby-source-strapi/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/gatsby-uc/plugins/issues"
   },
-  "homepage": "https://github.com/gatsby-uc/plugins/packages/gatsby-source-strapi#readme",
+  "homepage": "https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-source-strapi/README.md",
   "author": {
     "email": "hi@strapi.io",
     "name": "Strapi Solutions",


### PR DESCRIPTION
## Description

Fixed homepage links of packages.
Homepage are currently broken / unset for almost all plugins and it's annoying to navigate manually :) 
