### PR TITLE
docs(gatsby-source-strapi): add limitations

### DIFF
--- a/.changeset/giant-grapes-run.md
+++ b/.changeset/giant-grapes-run.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": patch
+---
+
+docs(gatsby-source-strapi): add limitations

--- a/packages/gatsby-source-strapi/README.md
+++ b/packages/gatsby-source-strapi/README.md
@@ -435,3 +435,5 @@ This plugin has several limitations, please be aware of these:
 - `fields`
 - `internal`
 - `parent`
+
+4. The `localizations` field is not properly supported. The entries are not references to the actual Gatsby nodes.


### PR DESCRIPTION
Add limitations to README:

* `localizations` don't refer to Gatsby nodes