### PR TITLE
feat(gatsby-source-strapi): link localizations

### DIFF
--- a/.changeset/gorgeous-camels-itch.md
+++ b/.changeset/gorgeous-camels-itch.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": major
+---
+
+feat(gatsby-source-strapi): link localizations to actual Gatsby nodes

--- a/packages/gatsby-source-strapi/src/clean-data.js
+++ b/packages/gatsby-source-strapi/src/clean-data.js
@@ -39,6 +39,15 @@ export const cleanAttributes = (attributes, currentSchema, schemas) => {
 
     const attributeName = restrictedFields.has(name) ? _.snakeCase(`strapi_${name}`) : name;
 
+    if (attributeName === "localizations" && currentSchema.schema.pluginOptions?.i18n?.localized) {
+      return {
+        ...accumulator,
+        [attributeName]: value.data.map(({ id, attributes }) =>
+          cleanAttributes({ id, ...attributes }, currentSchema, schemas)
+        ),
+      };
+    }
+
     if (!attribute?.type) {
       accumulator[attributeName] = value;
 

--- a/packages/gatsby-source-strapi/src/normalize.js
+++ b/packages/gatsby-source-strapi/src/normalize.js
@@ -177,7 +177,10 @@ export const createNodes = (entity, context, uid) => {
         delete entity[attributeName];
       }
 
-      if (type === "relation") {
+      if (
+        type === "relation" ||
+        (attributeName === "localizations" && schema.schema.pluginOptions?.i18n?.localized)
+      ) {
         // Create type for the first level of relations, otherwise the user should fetch the other content type
         // to link them
         const config = {
@@ -186,7 +189,7 @@ export const createNodes = (entity, context, uid) => {
           createNodeId,
           parentNode: entryNode,
           attributeName,
-          targetSchemaUid: attribute.target,
+          targetSchemaUid: type === "relation" ? attribute.target : uid,
         };
 
         if (Array.isArray(value)) {


### PR DESCRIPTION
Change the `localizations` field to a list that points to the Gatsby nodes of the corresponding translated content. Currently, the field contains the raw JSON data returned by the API.

Unfortunately, this change breaks backwards compatibility.