### PR TITLE
fix(gatsby-source-strapi): replace stub nodes

### DIFF
--- a/.changeset/spicy-days-worry.md
+++ b/.changeset/spicy-days-worry.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": patch
+---
+
+fix(gatsby-source-strapi): replace stub nodes from relations with full nodes

--- a/packages/gatsby-source-strapi/src/gatsby-node.js
+++ b/packages/gatsby-source-strapi/src/gatsby-node.js
@@ -148,7 +148,16 @@ export const sourceNodes = async (
     for (let entity of data[index]) {
       const nodes = createNodes(entity, context, uid);
 
-      await Promise.all(nodes.map((n) => createNode(n)));
+      await Promise.all(
+        nodes.map((n) => {
+          // Replace previously created stub nodes for relations
+          const relationStub = getNode(n.id);
+          if (relationStub) {
+            deleteNode(relationStub);
+          }
+          return createNode(n);
+        })
+      );
 
       const nodeType = makeParentNodeName(context.schemas, uid);
 


### PR DESCRIPTION
If a node is created first with `prepareRelationNode` and the "full" node is created later, the latter must replace the former. Otherwise the imported data is incomplete.