### PR TITLE
fix(server routes): fix path sent to GraphQL engine during DSG/SSR

### DIFF
--- a/packages/gatsby-plugin-fastify/src/plugins/server-routes.ts
+++ b/packages/gatsby-plugin-fastify/src/plugins/server-routes.ts
@@ -89,7 +89,7 @@ export const handleServerRoutes: FastifyPluginAsync<{
 
         if (accept.type(["html"])) {
           fastify.log.debug(`DSG/SSR for "text/html" @  ${request.url}`);
-          const potentialPagePath = reverseFixedPagePath(workingURL);
+          const potentialPagePath = reverseFixedPagePath(path);
           const page = graphqlEngine.findPageByPath(potentialPagePath);
 
           if (!page) {


### PR DESCRIPTION
<!--
  Have any questions? Hopefully we'll have docs soon, in the mean time
  ask in this Pull Request and a maintainer will be happy to help :)
-->

## Description

When Gatsby pathPrefix configuration is set the path name sent to GraphQL engine contains the prefixed version instead of the path that can be queried resulting in page not found error.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Fixes #458

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
