### PR TITLE
feat(gatsby-source-strapi): support strapi_document_id_or_regular_id

### DIFF
--- a/.changeset/three-walls-perform.md
+++ b/.changeset/three-walls-perform.md
@@ -4,7 +4,7 @@
 
 BREAKING CHANGES:
 
-- This plugin now assumes Strapi 5 by default.
+- This plugin now assumes Strapi 5 by default. If you are on Strapi 4, set `version: 4` in your plugin options, see the [readme](https://github.com/gatsby-uc/plugins/tree/main/packages/gatsby-source-strapi)
 - Previously `strapi_id` was filled with the `documentId`, now `strapi_id` will be the regular `id`.
 
 `documentId` is now added as a field.

--- a/.changeset/three-walls-perform.md
+++ b/.changeset/three-walls-perform.md
@@ -1,0 +1,13 @@
+---
+"gatsby-source-strapi": major
+---
+
+This plugin now assumes Strapi 5 by default.
+
+I've created a major release because I made a breaking change in the `strapi_id`.
+With the rewrite to `documentId`'s I assumed never needing the regular `id` anymore.
+Now I hit the usecase that the Users Permissions plugin doesn't use the `documentId`'s yet and needs regular `id`'s. So I need them in the Gatsby schema.
+
+In gatsby-source-strapi 4.0.0 `strapi_id` was filled with the `documentId`.
+
+In gatsby-source-strapi 5.0.0 `strapi_id` will be the regular `id`, `documentId` will be available and `strapi_document_id_or_regular_id` contains a mixture of the both. `documentId`'s when they are available, `id`'s for content without a `documentId` (for example media or components).

--- a/.changeset/three-walls-perform.md
+++ b/.changeset/three-walls-perform.md
@@ -2,12 +2,12 @@
 "gatsby-source-strapi": major
 ---
 
-This plugin now assumes Strapi 5 by default.
+BREAKING CHANGES:
 
-I've created a major release because I made a breaking change in the `strapi_id`.
-With the rewrite to `documentId`'s I assumed never needing the regular `id` anymore.
-Now I hit the usecase that the Users Permissions plugin doesn't use the `documentId`'s yet and needs regular `id`'s. So I need them in the Gatsby schema.
+- This plugin now assumes Strapi 5 by default.
+- Previously `strapi_id` was filled with the `documentId`, now `strapi_id` will be the regular `id`.
 
-In gatsby-source-strapi 4.0.0 `strapi_id` was filled with the `documentId`.
+`documentId` is now added as a field.
+`strapi_document_id_or_regular_id` contains a mixture of the both. `documentId`'s when they are available, `id`'s for content without a `documentId` (for example media or components).
 
-In gatsby-source-strapi 5.0.0 `strapi_id` will be the regular `id`, `documentId` will be available and `strapi_document_id_or_regular_id` contains a mixture of the both. `documentId`'s when they are available, `id`'s for content without a `documentId` (for example media or components).
+If you use `strapi_id` in your code assuming it is a Strapi 5 `documentId`, you have to rewrite that code to use the `documentId` field. More info why [in the PR](https://github.com/gatsby-uc/plugins/pull/498)

--- a/packages/gatsby-source-strapi/README.md
+++ b/packages/gatsby-source-strapi/README.md
@@ -73,7 +73,7 @@ require("dotenv").config({
 });
 
 const strapiConfig = {
-  version: 4, // Strapi version 4 or 5
+  version: 4, // Strapi version 4 or 5, defaults to 5
   apiURL: process.env.STRAPI_API_URL,
   accessToken: process.env.STRAPI_TOKEN,
   collectionTypes: ["article", "company", "author"],

--- a/packages/gatsby-source-strapi/src/clean-data.js
+++ b/packages/gatsby-source-strapi/src/clean-data.js
@@ -56,7 +56,7 @@ const getAttributes = (data, version) => {
  * @param {*} schemas
  * @returns
  */
-export const cleanAttributes = (attributes, currentSchema, schemas, version = 4) => {
+export const cleanAttributes = (attributes, currentSchema, schemas, version = 5) => {
   if (!attributes) {
     return;
   }
@@ -181,7 +181,7 @@ export const cleanAttributes = (attributes, currentSchema, schemas, version = 4)
  * @param {Object} ctx
  * @returns {Object}
  */
-export const cleanData = (data, context, version = 4) => {
+export const cleanData = (data, context, version = 5) => {
   const { schemas, contentTypeUid } = context;
   const currentContentTypeSchema = getContentTypeSchema(schemas, contentTypeUid);
   return {

--- a/packages/gatsby-source-strapi/src/fetch.js
+++ b/packages/gatsby-source-strapi/src/fetch.js
@@ -22,8 +22,8 @@ export const fetchStrapiContentTypes = async (axiosInstance) => {
   };
 };
 
-const convertQueryParameters = (queryParameters, version = 4) => {
-  if (version == 4) {
+const convertQueryParameters = (queryParameters, version = 5) => {
+  if (version === 4) {
     return queryParameters;
   }
   // assume v5.
@@ -40,7 +40,7 @@ const convertQueryParameters = (queryParameters, version = 4) => {
 };
 
 export const fetchEntity = async (
-  { endpoint, queryParams, uid, pluginOptions, version = 4 },
+  { endpoint, queryParams, uid, pluginOptions, version = 5 },
   context,
 ) => {
   const { reporter, axiosInstance } = context;
@@ -125,7 +125,7 @@ export const fetchEntity = async (
 };
 
 export const fetchEntities = async (
-  { endpoint, queryParams, uid, pluginOptions, version = 4 },
+  { endpoint, queryParams, uid, pluginOptions, version = 5 },
   context,
 ) => {
   const { reporter, axiosInstance } = context;

--- a/packages/gatsby-source-strapi/src/gatsby-node.js
+++ b/packages/gatsby-source-strapi/src/gatsby-node.js
@@ -22,7 +22,7 @@ export const sourceNodes = async (
   },
   strapiConfig,
 ) => {
-  reporter.info(`gatsby-source-strapi is using Strapi version ${strapiConfig.version || 4}`);
+  reporter.info(`gatsby-source-strapi is using Strapi version ${strapiConfig.version || 5}`);
 
   // Cast singleTypes and collectionTypes to empty arrays if they're not defined
   if (!Array.isArray(strapiConfig.singleTypes)) {

--- a/packages/gatsby-source-strapi/src/helpers.js
+++ b/packages/gatsby-source-strapi/src/helpers.js
@@ -3,7 +3,7 @@ import _ from "lodash";
 const buildMapFromNodes = (nodes) => {
   // eslint-disable-next-line unicorn/no-array-reduce
   return nodes.reduce((accumulator, current) => {
-    const { internal, strapi_id, id } = current;
+    const { internal, strapi_document_id_or_regular_id, id } = current;
     const type = internal?.type;
 
     // We only delete the parent nodes
@@ -19,18 +19,18 @@ const buildMapFromNodes = (nodes) => {
       return accumulator;
     }
 
-    if (type && id && strapi_id) {
+    if (type && id && strapi_document_id_or_regular_id) {
       accumulator[type] = accumulator[type]
         ? [
             ...accumulator[type],
             {
-              strapi_id,
+              strapi_document_id_or_regular_id,
               id,
             },
           ]
         : [
             {
-              strapi_id,
+              strapi_document_id_or_regular_id,
               id,
             },
           ];
@@ -49,8 +49,10 @@ const buildMapFromData = (endpoints, data) => {
     for (let entity of data[index]) {
       // f.e. components do not have a documentId, allow regular id
       // also, support both v5 documentId and v4 id
-      const strapi_id = entity.documentId || entity.id;
-      map[nodeType] = map[nodeType] ? [...map[nodeType], { strapi_id }] : [{ strapi_id }];
+      const strapi_document_id_or_regular_id = entity.documentId || entity.id;
+      map[nodeType] = map[nodeType]
+        ? [...map[nodeType], { strapi_document_id_or_regular_id }]
+        : [{ strapi_document_id_or_regular_id }];
     }
   }
 
@@ -71,7 +73,9 @@ const buildNodesToRemoveMap = (existingNodesMap, endpoints, data) => {
     }
 
     accumulator[name] = value.filter((index) => {
-      return !currentNodes.some((k) => k.strapi_id === index.strapi_id);
+      return !currentNodes.some(
+        (k) => k.strapi_document_id_or_regular_id === index.strapi_document_id_or_regular_id,
+      );
     });
 
     return accumulator;

--- a/packages/gatsby-source-strapi/src/helpers.js
+++ b/packages/gatsby-source-strapi/src/helpers.js
@@ -90,7 +90,7 @@ const getContentTypeSchema = (schemas, ctUID) => {
   return currentContentTypeSchema;
 };
 
-const getEndpoints = ({ collectionTypes, singleTypes, version = 4 }, schemas) => {
+const getEndpoints = ({ collectionTypes, singleTypes, version = 5 }, schemas) => {
   const types = normalizeConfig({ collectionTypes, singleTypes });
 
   const endpoints = schemas

--- a/packages/gatsby-source-strapi/src/normalize.js
+++ b/packages/gatsby-source-strapi/src/normalize.js
@@ -13,7 +13,7 @@ const prepareJSONNode = (json, context) => {
   const { createContentDigest, createNodeId, parentNode, attributeName } = context;
 
   const jsonNodeId = createNodeId(
-    `${parentNode.strapi_id}-${parentNode.internal.type}-${attributeName}-JSONNode`,
+    `${parentNode.strapi_document_id_or_regular_id}-${parentNode.internal.type}-${attributeName}-JSONNode`,
   );
 
   const JSONNode = {
@@ -47,13 +47,15 @@ const prepareRelationNode = (relation, context) => {
   // } = targetSchema;
 
   const nodeType = makeParentNodeName(schemas, targetSchemaUid);
-  const strapi_id = relation.documentId || relation.id; // support both v5 and v4
-  const relationNodeId = createNodeId(`${nodeType}-${strapi_id}`);
+  const strapi_document_id_or_regular_id = relation.documentId || relation.id; // support both v5 and v4
+  const relationNodeId = createNodeId(`${nodeType}-${strapi_document_id_or_regular_id}`);
 
   const node = {
     ...relation,
     id: relationNodeId,
-    strapi_id,
+    documentId: relation.documentId,
+    strapi_id: relation.id,
+    strapi_document_id_or_regular_id,
     parent: parentNode.id,
     children: [],
     internal: {
@@ -75,7 +77,7 @@ const prepareRelationNode = (relation, context) => {
 const prepareTextNode = (text, context) => {
   const { createContentDigest, createNodeId, parentNode, attributeName } = context;
   const textNodeId = createNodeId(
-    `${parentNode.strapi_id}-${parentNode.internal.type}-${attributeName}-TextNode`,
+    `${parentNode.strapi_document_id_or_regular_id}-${parentNode.internal.type}-${attributeName}-TextNode`,
   );
 
   const textNode = {
@@ -110,6 +112,7 @@ const prepareMediaNode = (media, context) => {
     ...media,
     id: relationNodeId,
     strapi_id: media.id,
+    strapi_document_id_or_regular_id: media.id,
     parent: parentNode.id,
     children: [],
     internal: {
@@ -138,11 +141,13 @@ export const createNodes = (entity, context, uid) => {
 
   // f.e. components do not have a documentId, allow regular id
   // also, support both v5 documentId and v4 id
-  const strapi_id = entity.documentId || entity.id;
+  const strapi_document_id_or_regular_id = entity.documentId || entity.id;
 
   let entryNode = {
-    id: createNodeId(`${nodeType}-${strapi_id}`),
-    strapi_id,
+    id: createNodeId(`${nodeType}-${strapi_document_id_or_regular_id}`),
+    documentId: entity.documentId,
+    strapi_id: entity.id,
+    strapi_document_id_or_regular_id,
     parent: undefined,
     children: [],
     internal: {


### PR DESCRIPTION
I now assume Strapi 5 by default. Makes more sense.


I've created a major release because I made a breaking change in the `strapi_id`.
With the rewrite to `documentId`'s I assumed never needing the regular `id` anymore.
Now I hit the usecase that the Users Permissions plugin doesn't use the `documentId`'s yet and needs regular `id`'s. So I need them in the Gatsby schema.

In gatsby-source-strapi 4.0.0 `strapi_id` was filled with the `documentId`.

In gatsby-source-strapi 5.0.0 `strapi_id` will be the regular `id`, `documentId` will be available and `strapi_document_id_or_regular_id` contains a mixture of the both. `documentId`'s when they are available, `id`'s for content without a `documentId` (for example media or components).

I feel like a major is appropriate, as 4.0.0 sees NPM download already. Somebody might be using `strapi_id` assuming `documentId`'s 