### PR TITLE
bug(gatsby-source-strapi): reduce the queryLimit to Strapi default 100

### DIFF
--- a/.changeset/plenty-dolls-knock.md
+++ b/.changeset/plenty-dolls-knock.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": patch
+---
+
+reduce the queryLimit to Strapi default 100

--- a/packages/gatsby-source-strapi/src/helpers.js
+++ b/packages/gatsby-source-strapi/src/helpers.js
@@ -129,7 +129,7 @@ const getEndpoints = ({ collectionTypes, singleTypes, version = 5 }, schemas) =>
         queryParams: {
           ...queryParams,
           pagination: {
-            pageSize: queryLimit || 250,
+            pageSize: queryLimit || 100,
             page: 1,
           },
           populate: queryParams?.populate || "*",


### PR DESCRIPTION
Given:
- Strapi 5 response when going over the queryLimit has a breaking change: https://github.com/strapi/strapi/issues/22483
- the default query limit for Strapi is 100 
we should change the default queryLimit at our side to 100 as well. 

Currently, requesting over 100 items to v5 without setting queryLimits on either side will result in missing data. I learned that the hard way...