### PR TITLE
fix(gatsby-source-strapi): Fix "locale=all" i18n feature for Single Types and Collection Types

### DIFF
--- a/packages/gatsby-source-strapi/src/normalize.js
+++ b/packages/gatsby-source-strapi/src/normalize.js
@@ -142,6 +142,9 @@ export const createNodes = (entity, context, uid) => {
   // f.e. components do not have a documentId, allow regular id
   // also, support both v5 documentId and v4 id
   const strapi_document_id_or_regular_id = entity.documentId || entity.id;
+
+  // localizations of the same entity will have the same documentId
+  // so the locale is included to prevent localized entries from overwriting each other
   const locale = entity.locale ? `-${entity.locale}` : '';
 
   let entryNode = {

--- a/packages/gatsby-source-strapi/src/normalize.js
+++ b/packages/gatsby-source-strapi/src/normalize.js
@@ -142,9 +142,10 @@ export const createNodes = (entity, context, uid) => {
   // f.e. components do not have a documentId, allow regular id
   // also, support both v5 documentId and v4 id
   const strapi_document_id_or_regular_id = entity.documentId || entity.id;
+  const locale = entity.locale ? `-${entity.locale}` : '';
 
   let entryNode = {
-    id: createNodeId(`${nodeType}-${strapi_document_id_or_regular_id}`),
+    id: createNodeId(`${nodeType}-${strapi_document_id_or_regular_id}${locale}`),
     documentId: entity.documentId,
     strapi_id: entity.id,
     strapi_document_id_or_regular_id,


### PR DESCRIPTION
## Description

The linked issue seems to occur because, in Strapi, localized entries share the same documentId, so localized entries override each other when the plugin sources them from Strapi. This is fixed by providing entry.locale (if present) to the `createNodeId` call.

Additionally, this pull request also fixes the handling of `locale=all` in queries. For collection types, it appears that `locale=*` still works to fetch all entries of all localizations in Strapi v5, so I stuck with that for now...

I have tested this in my application with Strapi v4 & v5, both compiling without problems. I have *not* tested the new code for an application not using i18 though.

### Documentation

https://github.com/gatsby-uc/plugins/blob/main/packages/gatsby-source-strapi/README.md#internationalization This documentation should likely change... please correct me if I overlooked something, but there are no mentions of Strapi v5's breaking changes here. Was a bit confusing, maybe that should be amended in the meantime until these changes are merged?

Anyway, I don't think this documentation needs to change for now, with my changes in mind.

## Related Issues

Fixes #509
