### PR TITLE
fix(gatsby-source-strapi): Strapi v5 Fix "locale=all" i18n feature for Single Types and Collection Types

### DIFF
--- a/.changeset/little-socks-approve.md
+++ b/.changeset/little-socks-approve.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-strapi": patch
+---
+
+fix(gatsby-source-strapi): Strapi v5 Fix "locale=all" i18n feature for Single Types and Collection Types

--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
   },
   "run-if-changed": {
     "renovate.json5": "yarn renovate-config-validator"
-  }
+  },
+  "version": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,5 @@
   },
   "run-if-changed": {
     "renovate.json5": "yarn renovate-config-validator"
-  },
-  "version": "0.0.0"
+  }
 }

--- a/packages/gatsby-source-strapi/src/fetch.js
+++ b/packages/gatsby-source-strapi/src/fetch.js
@@ -83,8 +83,8 @@ export const fetchEntity = async (
             },
           },
         });
-        for (const localization of response.data.attributes.localizations.data) {
-          otherLocales.push(localization.attributes.locale);
+        for (const localization of response.data.localizations) {
+          otherLocales.push(localization.locale);
         }
       } else {
         // Only one locale
@@ -140,65 +140,119 @@ export const fetchEntities = async (
     },
   };
 
-  // Use locale from pluginOptions if it's defined
-  if (pluginOptions?.i18n?.locale) {
+  // Handle internationalization
+  const locale = pluginOptions?.i18n?.locale;
+  const localesToFetch = [];
+
+  if (locale) {
     delete queryParams.locale;
-    queryParams.locale = pluginOptions.i18n.locale;
+
+    if (locale === "all") {
+      // Get all available locales from first entity
+      const { data: previewResponse } = await axiosInstance({
+        ...options,
+        params: {
+          ...options.params,
+          pagination: { pageSize: 1 },
+          populate: {
+            localizations: {
+              fields: ["locale"],
+            },
+          },
+        },
+      });
+
+      // Add default locale from first entry
+      if (previewResponse.data?.[0]) {
+        const firstEntry = previewResponse.data[0];
+        const localesSet = new Set();
+
+        // Add current entry's locale
+        if (firstEntry.locale) {
+          localesSet.add(firstEntry.locale);
+        }
+
+        // Add other locales from localizations array or data property
+        const localizations = firstEntry.localizations?.data || firstEntry.localizations || [];
+        for (const localization of localizations) {
+          const localeValue = localization.locale || localization.attributes?.locale;
+          if (localeValue) {
+            localesSet.add(localeValue);
+          }
+        }
+
+        localesToFetch.push(...localesSet);
+      }
+    } else {
+      // Only one locale
+      localesToFetch.push(locale);
+    }
+  } else {
+    // No locale specified, fetch default
+    localesToFetch.push(undefined);
   }
 
   try {
-    reporter.info(
-      `Starting to fetch data from Strapi - ${
-        options.url
-      } with ${options.paramsSerializer.serialize(options.params)}`,
-    );
+    // Fetch data for each locale
+    const allLocalesData = [];
 
-    const { data: response } = await axiosInstance(options);
+    for (const currentLocale of localesToFetch) {
+      const localeOptions = {
+        ...options,
+        params: {
+          ...options.params,
+          ...(currentLocale && { locale: currentLocale }),
+        },
+      };
 
-    const data = response?.data || response;
-    const meta = response?.meta;
+      const { data: response } = await axiosInstance(localeOptions);
 
-    const page = Number.parseInt(meta?.pagination.page || 1, 10);
-    const pageCount = Number.parseInt(meta?.pagination.pageCount || 1, 10);
+      const data = response?.data || response;
+      const meta = response?.meta;
 
-    const pagesToGet = Array.from({
-      length: pageCount - page,
-    }).map((_, index) => index + page + 1);
+      const page = Number.parseInt(meta?.pagination.page || 1, 10);
+      const pageCount = Number.parseInt(meta?.pagination.pageCount || 1, 10);
 
-    const fetchPagesPromises = pagesToGet.map((page) => {
-      return (async () => {
-        const fetchOptions = {
-          ...options,
-          params: {
-            ...options.params,
-            pagination: {
-              ...options.params.pagination,
-              page,
+      const pagesToGet = Array.from({
+        length: pageCount - page,
+      }).map((_, index) => index + page + 1);
+
+      const fetchPagesPromises = pagesToGet.map((page) => {
+        return (async () => {
+          const fetchOptions = {
+            ...localeOptions,
+            params: {
+              ...localeOptions.params,
+              pagination: {
+                ...localeOptions.params.pagination,
+                page,
+              },
             },
-          },
-        };
+          };
 
-        reporter.info(
-          `Starting to fetch page ${page} from Strapi - ${
-            fetchOptions.url
-          } with ${options.paramsSerializer.serialize(fetchOptions.params)}`,
-        );
+          reporter.info(
+            `Starting to fetch page ${page} from Strapi - ${
+              fetchOptions.url
+            } with ${options.paramsSerializer.serialize(fetchOptions.params)}`,
+          );
 
-        try {
-          const {
-            data: { data },
-          } = await axiosInstance(fetchOptions);
+          try {
+            const {
+              data: { data },
+            } = await axiosInstance(fetchOptions);
 
-          return data;
-        } catch (error) {
-          reporter.panic(`Failed to fetch data from Strapi ${fetchOptions.url}`, error);
-        }
-      })();
-    });
+            return data;
+          } catch (error) {
+            reporter.panic(`Failed to fetch data from Strapi ${fetchOptions.url}`, error);
+          }
+        })();
+      });
 
-    const results = await Promise.all(fetchPagesPromises);
+      const results = await Promise.all(fetchPagesPromises);
+      allLocalesData.push(...data, ...flattenDeep(results));
+    }
 
-    const cleanedData = [...data, ...flattenDeep(results)].map((entry) =>
+    const cleanedData = allLocalesData.map((entry) =>
       cleanData(entry, { ...context, contentTypeUid: uid }, version),
     );
 

--- a/packages/gatsby-source-strapi/src/normalize.js
+++ b/packages/gatsby-source-strapi/src/normalize.js
@@ -12,9 +12,8 @@ import { getContentTypeSchema, makeParentNodeName } from "./helpers";
 const prepareJSONNode = (json, context) => {
   const { createContentDigest, createNodeId, parentNode, attributeName } = context;
 
-  const jsonNodeId = createNodeId(
-    `${parentNode.strapi_document_id_or_regular_id}-${parentNode.internal.type}-${attributeName}-JSONNode`,
-  );
+  // Use parentNode.id instead of strapi_document_id_or_regular_id to ensure uniqueness across locales
+  const jsonNodeId = createNodeId(`${parentNode.id}-${attributeName}-JSONNode`);
 
   const JSONNode = {
     ...(_.isPlainObject(json) ? { ...json } : { strapi_json_value: json }),
@@ -48,7 +47,12 @@ const prepareRelationNode = (relation, context) => {
 
   const nodeType = makeParentNodeName(schemas, targetSchemaUid);
   const strapi_document_id_or_regular_id = relation.documentId || relation.id; // support both v5 and v4
-  const relationNodeId = createNodeId(`${nodeType}-${strapi_document_id_or_regular_id}`);
+
+  // Include locale in node ID to support multiple locales for the same entity
+  const localeIdentifier = relation.locale ? `-${relation.locale}` : "";
+  const relationNodeId = createNodeId(
+    `${nodeType}-${strapi_document_id_or_regular_id}${localeIdentifier}`,
+  );
 
   const node = {
     ...relation,
@@ -76,9 +80,8 @@ const prepareRelationNode = (relation, context) => {
  */
 const prepareTextNode = (text, context) => {
   const { createContentDigest, createNodeId, parentNode, attributeName } = context;
-  const textNodeId = createNodeId(
-    `${parentNode.strapi_document_id_or_regular_id}-${parentNode.internal.type}-${attributeName}-TextNode`,
-  );
+  // Use parentNode.id instead of strapi_document_id_or_regular_id to ensure uniqueness across locales
+  const textNodeId = createNodeId(`${parentNode.id}-${attributeName}-TextNode`);
 
   const textNode = {
     id: textNodeId,
@@ -143,8 +146,11 @@ export const createNodes = (entity, context, uid) => {
   // also, support both v5 documentId and v4 id
   const strapi_document_id_or_regular_id = entity.documentId || entity.id;
 
+  // Include locale in node ID to support multiple locales for the same entity
+  const localeIdentifier = entity.locale ? `-${entity.locale}` : "";
+
   let entryNode = {
-    id: createNodeId(`${nodeType}-${strapi_document_id_or_regular_id}`),
+    id: createNodeId(`${nodeType}-${strapi_document_id_or_regular_id}${localeIdentifier}`),
     documentId: entity.documentId,
     strapi_id: entity.id,
     strapi_document_id_or_regular_id,

--- a/packages/gatsby-source-strapi/src/normalize.js
+++ b/packages/gatsby-source-strapi/src/normalize.js
@@ -12,8 +12,9 @@ import { getContentTypeSchema, makeParentNodeName } from "./helpers";
 const prepareJSONNode = (json, context) => {
   const { createContentDigest, createNodeId, parentNode, attributeName } = context;
 
-  // Use parentNode.id instead of strapi_document_id_or_regular_id to ensure uniqueness across locales
-  const jsonNodeId = createNodeId(`${parentNode.id}-${attributeName}-JSONNode`);
+  const jsonNodeId = createNodeId(
+    `${parentNode.strapi_document_id_or_regular_id}-${parentNode.internal.type}-${attributeName}-JSONNode`,
+  );
 
   const JSONNode = {
     ...(_.isPlainObject(json) ? { ...json } : { strapi_json_value: json }),


### PR DESCRIPTION
## Description

Some of the job have been done previously to handle strapi v5 with this plugin, but, since they removed locale==all parameter when migrating strapi from v4 to v5, it is impossible to fetch multiple locales

[See strapi migration page](https://docs.strapi.io/cms/migration/v4-to-v5/breaking-changes/no-locale-all)

**So what i did is** 
- Add support for locale='all' to fetch all available locales
- Fix node ID conflicts by including locale in unique identifiers
- Improve localization data handling for Strapi v5

The workflow i proposed consist in
- fix easily for singleTypes 
- fix collectionTypes (`fetchEntities` func) by fetch an element with localizations, then loop on all locales to do one query per locale (and with actual system on pagination)

### Documentation

no need to change, my PR contribute to keep the actual configuration

@moonmeister could you plase me send a feedback ? Thanks

## Related Issues
Fixes #509