### PR TITLE
fix(gatsby-source-strapi): nested relation cache invalidation

### DIFF
--- a/packages/gatsby-source-strapi/src/clean-data.js
+++ b/packages/gatsby-source-strapi/src/clean-data.js
@@ -228,10 +228,6 @@ export const cleanData = (data, context, version = 5) => {
     version,
   );
   const latest = findLatestDates(cleaned);
-
-  // log clean.updatedAt and latest.updatedAt to check if the latest dates are correctly calculated
-  console.log(`clean.updatedAt: ${cleaned.updatedAt}, latest.updatedAt: ${latest.updatedAt}`);
-
   return {
     ...cleaned,
     updatedAt: latest.updatedAt || cleaned.updatedAt || undefined,

--- a/packages/gatsby-source-strapi/src/clean-data.js
+++ b/packages/gatsby-source-strapi/src/clean-data.js
@@ -49,6 +49,43 @@ const getAttributes = (data, version) => {
   return data;
 };
 
+// Recursively finds the latest updatedAt and publishedAt dates in the data object.
+// This ensures that caching mechanisms that rely on these timestamps will work correctly
+// when nested relations have more recent updates than their parent entities.
+const findLatestDates = (data) => {
+  let maxUpdatedAt;
+  let maxPublishedAt;
+
+  // helper function to check and update the max dates
+  function checkDate(value, key) {
+    if (typeof value === "string" && (key === "updatedAt" || key === "publishedAt")) {
+      if (key === "updatedAt" && (!maxUpdatedAt || value > maxUpdatedAt)) {
+        maxUpdatedAt = value;
+      }
+      if (key === "publishedAt" && (!maxPublishedAt || value > maxPublishedAt)) {
+        maxPublishedAt = value;
+      }
+    }
+  }
+
+  // recursive function to traverse the entire data object
+  function traverse(node) {
+    if (Array.isArray(node)) {
+      for (const value of node) {
+        traverse(value);
+      }
+    } else if (node && typeof node === "object") {
+      for (const [key, value] of Object.entries(node)) {
+        checkDate(value, key);
+        traverse(value);
+      }
+    }
+  }
+
+  traverse(data);
+  return { updatedAt: maxUpdatedAt, publishedAt: maxPublishedAt };
+};
+
 /**
  * Removes the attribute key in the entire data.
  * @param {Object} attributes response from the API
@@ -184,7 +221,20 @@ export const cleanAttributes = (attributes, currentSchema, schemas, version = 5)
 export const cleanData = (data, context, version = 5) => {
   const { schemas, contentTypeUid } = context;
   const currentContentTypeSchema = getContentTypeSchema(schemas, contentTypeUid);
+  const cleaned = cleanAttributes(
+    getAttributes(data, version),
+    currentContentTypeSchema,
+    schemas,
+    version,
+  );
+  const latest = findLatestDates(cleaned);
+
+  // log clean.updatedAt and latest.updatedAt to check if the latest dates are correctly calculated
+  console.log(`clean.updatedAt: ${cleaned.updatedAt}, latest.updatedAt: ${latest.updatedAt}`);
+
   return {
-    ...cleanAttributes(getAttributes(data, version), currentContentTypeSchema, schemas, version),
+    ...cleaned,
+    updatedAt: latest.updatedAt || cleaned.updatedAt || undefined,
+    publishedAt: latest.publishedAt || cleaned.publishedAt || undefined,
   };
 };


### PR DESCRIPTION
<!--
  Have any questions? Hopefully we'll have docs soon, in the mean time
  ask in this Pull Request and a maintainer will be happy to help :)
-->

## Description

Gatsby's cache invalidation for `gatsby-source-strapi` only considered the top-level `updatedAt`/`publishedAt` fields on a Strapi entry. When a nested relation was updated in Strapi, the parent entry's top-level timestamps remained unchanged — causing Gatsby to treat the entry as unmodified and serve stale data.

### Solution

Added a `findLatestDates` utility to clean-data.js that recursively traverses the entire cleaned entry — including all nested objects and arrays — and returns the maximum updatedAt and publishedAt values found anywhere in the document tree.

cleanData now overwrites the top-level updatedAt and publishedAt with these maximums before returning, ensuring that any change to any relation at any depth of nesting will correctly bust the cache.

Compatible with both Strapi v4 and v5 because `findLatestDates` operates on the output of `cleanAttributes`, not on the raw API response.

## Related Issues

Fixes #523 